### PR TITLE
Add support for different ssl_mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,18 @@ starrocks:
       password: your_starrocks_password
 ```
 
-| Option   | Description                                            | Required? | Example                        |
-|----------|--------------------------------------------------------|-----------|--------------------------------|
-| type     | The specific adapter to use                            | Required  | `starrocks`                    |
-| host     | The hostname to connect to                             | Required  | `192.168.100.28`               |
-| port     | The port to use                                        | Required  | `9030`                         |
-| schema   | Specify the schema (database) to build models into     | Required  | `analytics`                    |
-| username | The username to use to connect to the server           | Required  | `dbt_admin`                    |
-| password | The password to use for authenticating to the server   | Required  | `correct-horse-battery-staple` |
-| version  | Let Plugin try to go to a compatible starrocks version | Optional  | `3.1.0`                        |
+| Option   | Description                                             | Required? | Example                        |
+|----------|---------------------------------------------------------|-----------|--------------------------------|
+| type     | The specific adapter to use                             | Required  | `starrocks`                    |
+| host     | The hostname to connect to                              | Required  | `192.168.100.28`               |
+| port     | The port to use                                         | Required  | `9030`                         |
+| schema   | Specify the schema (database) to build models into      | Required  | `analytics`                    |
+| username | The username to use to connect to the server            | Required  | `dbt_admin`                    |
+| password | The password to use for authenticating to the server    | Required  | `correct-horse-battery-staple` |
+| version  | Let Plugin try to go to a compatible starrocks version  | Optional  | `3.1.0`                        |
+| ssl      | json string to specify SSL_MODE for the mysql connector | Optional  | `'{"ca": "path/to/ca.pem"}'`   |
+
+More details about configuring SSL_MODE for the connector [here](https://stackoverflow.com/questions/60285240/is-there-a-way-to-emulate-ssl-mode-preferred-in-pymysql)
 
 
 ## Example

--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -16,6 +16,8 @@
 from contextlib import contextmanager
 
 import json
+from json.decoder.json import JSONDecodeError
+
 import mysql.connector
 
 import dbt.exceptions
@@ -115,7 +117,10 @@ class StarRocksConnectionManager(SQLConnectionManager):
             kwargs["port"] = credentials.port
 
         if credentials.ssl:
-            kwargs["ssl"] = json.loads(credentials.ssl)
+            try:
+                kwargs["ssl"] = json.loads(credentials.ssl)
+            except JSONDecodeError:
+                logger.debug("Failed to decode SSL config. Falling back to no SSL config.")
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -15,6 +15,7 @@
 
 from contextlib import contextmanager
 
+import json
 import mysql.connector
 
 import dbt.exceptions
@@ -40,6 +41,7 @@ class StarRocksCredentials(Credentials):
     password: Optional[str] = None
     charset: Optional[str] = None
     version: Optional[str] = None
+    ssl: Optional[str] = None
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
@@ -76,6 +78,7 @@ class StarRocksCredentials(Credentials):
             "schema",
             "catalog",
             "username",
+            "ssl",
         )
 
 
@@ -110,6 +113,9 @@ class StarRocksConnectionManager(SQLConnectionManager):
         
         if credentials.port:
             kwargs["port"] = credentials.port
+
+        if credentials.ssl:
+            kwargs["ssl"] = json.loads(credentials.ssl)
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)


### PR DESCRIPTION
I am running [mysql-proxy](https://github.com/cppforlife/mysql-proxy) in front of my starrocks FE nodes with SSL mode required.

This PR adds support for specifying ssl mode for mysql-connector-python so that I can connect with the equivalent of SSL_MODE=REQUIRED.

Example configs here: https://stackoverflow.com/questions/60285240/is-there-a-way-to-emulate-ssl-mode-preferred-in-pymysql