### PR TITLE
enforce encoding='utf8'

### DIFF
--- a/dbt/adapters/starrocks/__version__.py
+++ b/dbt/adapters/starrocks/__version__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.6.1"
+version = "1.7.10"

--- a/dbt/adapters/starrocks/__version__.py
+++ b/dbt/adapters/starrocks/__version__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.7.10"
+version = "1.6.1"

--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -16,7 +16,7 @@
 from contextlib import contextmanager
 
 import json
-from json.decoder.json import JSONDecodeError
+from json.decoder import JSONDecodeError
 
 import mysql.connector
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,3 @@
 pytest
 pytest-dotenv
-dbt-tests-adapter==1.6.10
+dbt-tests-adapter==1.7.10

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 
 # pull long description from README
 this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, "README.md")) as f:
+with open(os.path.join(this_directory, "README.md"), encoding='utf8') as f:
     long_description = f.read()
 
 package_name = "dbt-starrocks"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(os.path.join(this_directory, "README.md"), encoding='utf8') as f:
 
 package_name = "dbt-starrocks"
 # make sure this always matches dbt/adapters/starrocks/__version__.py
-package_version = "1.7.10"
+package_version = "1.6.1"
 description = """The Starrocks adapter plugin for dbt"""
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(os.path.join(this_directory, "README.md"), encoding='utf8') as f:
 
 package_name = "dbt-starrocks"
 # make sure this always matches dbt/adapters/starrocks/__version__.py
-package_version = "1.6.1"
+package_version = "1.7.10"
 description = """The Starrocks adapter plugin for dbt"""
 
 
@@ -57,7 +57,7 @@ setup(
     packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     include_package_data=True,
     install_requires=[
-        "dbt-core~=1.6.0",
+        "dbt-core~=1.7.10",
         "mysql-connector-python>=8.1",
     ],
     zip_safe=False,


### PR DESCRIPTION
Installation on Windows 10 is not possible unless we enforce encoding='utf8'