### PR TITLE
Remove broken SSL option and add `use_pure` option to enable C extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ starrocks:
 | username | The username to use to connect to the server            | Required  | `dbt_admin`                    |
 | password | The password to use for authenticating to the server    | Required  | `correct-horse-battery-staple` |
 | version  | Let Plugin try to go to a compatible starrocks version  | Optional  | `3.1.0`                        |
-| ssl      | json string to specify SSL_MODE for the mysql connector | Optional  | `'{"ca": "path/to/ca.pem"}'`   |
+| use_pure | set to "true" to use C extensions                       | Optional  | `true`                         |
 
-More details about configuring SSL_MODE for the connector [here](https://stackoverflow.com/questions/60285240/is-there-a-way-to-emulate-ssl-mode-preferred-in-pymysql)
+More details about setting `use_pure` and other connection arguments [here](https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html)
 
 
 ## Example

--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -15,9 +15,6 @@
 
 from contextlib import contextmanager
 
-import json
-from json import JSONDecodeError
-
 import mysql.connector
 
 import dbt.exceptions
@@ -43,7 +40,7 @@ class StarRocksCredentials(Credentials):
     password: Optional[str] = None
     charset: Optional[str] = None
     version: Optional[str] = None
-    ssl: Optional[str] = None
+    use_pure: Optional[str] = None
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
@@ -80,7 +77,7 @@ class StarRocksCredentials(Credentials):
             "schema",
             "catalog",
             "username",
-            "ssl",
+            "use_pure",
         )
 
 
@@ -116,11 +113,8 @@ class StarRocksConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
-        if credentials.ssl:
-            try:
-                kwargs["ssl"] = json.loads(credentials.ssl)
-            except JSONDecodeError:
-                logger.debug("Failed to decode SSL config. Falling back to no SSL config.")
+        if credentials.use_pure in ["true", "True"]:
+            kwargs["use_pure"] = True
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)


### PR DESCRIPTION
- SSL option is broken. Removing it (I added it oops).
- Adding `use_pure` option which enables/disables C extensions. C extension version of mysql connector has better defaults regarding enabling/disabling SSL connections. Example of a problem it solves is [here](https://stackoverflow.com/questions/54485148/ssl-connection-error-while-using-mysql-connector-with-python)