### PR TITLE
Add support for `microbatch` incremental strategy on `dbt-core` 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ models:
   
   // For 'materialized=incremental' in version >= 3.4
   incremental_strategy: 'dynamic_overwrite' // Supported values: ['default', 'insert_overwrite', 'dynamic_overwrite']
+
+  // For 'materialized=incremental' and 'incremental_strategy=microbatch'
+  event_time: 'some_timestamp_column'     // The column name of the event time
+  begin: '2025-01-01'                     // The start time of the incremental data
+  lookback: 1                             // The lookback time of the each incremental run
+  batch_size: 'day'                       // The batch size. Supported values ['year', 'month', 'day', 'hour']
+  microbatch_use_dynamic_overwrite: true  // Whether to use dynamic_overwrite in version >= 3.4
 ```
   
 ### dbt run config:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ pip install dbt-starrocks
 |        ❌         |          ❌          |        ✅         |        ✅         |       Expression Partition        |
 |        ❌         |          ❌          |        ❌         |        ❌         |               Kafka               |
 |        ❌         |          ❌          |        ❌         |        ✅         |         Dynamic Overwrite         |
+|        ❌         |          ✅          |        ✅         |        ✅         |  Microbatch (Insert Overwrite)   |
+|        ❌         |          ❌          |        ❌         |        ✅         | Microbatch (Dynamic Overwrite)   |
 
 ### Notice
 1. When StarRocks Version < 2.5, `Create table as` can only set engine='OLAP' and table_type='DUPLICATE'
@@ -111,6 +113,8 @@ models:
 {{ config(materialized='table', table_type='PRIMARY', keys=['customer_id'], order_by=['first_name', 'last_name'] }}
 {{ config(materialized='incremental', table_type='PRIMARY', engine='OLAP', buckets=32, distributed_by=['id']) }}
 {{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='dynamic_overwrite') }}
+{{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='microbatch', event_time='day', begin='2025-01-01', lookback=1, batch_size='day') }}
+{{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='microbatch', event_time='day', begin='2025-01-01', lookback=1, batch_size='day', microbatch_use_dynamic_overwrite=true) }}
 {{ config(materialized='materialized_view') }}
 {{ config(materialized='materialized_view', properties={"storage_medium":"SSD"}) }}
 {{ config(materialized='materialized_view', refresh_method="ASYNC START('2022-09-01 10:00:00') EVERY (interval 1 day)") }}

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ models:
 {{ config(materialized='table', table_type='PRIMARY', keys=['customer_id'], order_by=['first_name', 'last_name'] }}
 {{ config(materialized='incremental', table_type='PRIMARY', engine='OLAP', buckets=32, distributed_by=['id']) }}
 {{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='dynamic_overwrite') }}
-{{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='microbatch', event_time='day', begin='2025-01-01', lookback=1, batch_size='day') }}
-{{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='microbatch', event_time='day', begin='2025-01-01', lookback=1, batch_size='day', microbatch_use_dynamic_overwrite=true) }}
+{{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='microbatch', event_time='report_day', begin='2025-01-01', lookback=1, batch_size='day') }}
+{{ config(materialized='incremental', partition_by=['my_partition_key'], partition_type='Expr', incremental_strategy='microbatch', event_time='report_day', begin='2025-01-01', lookback=1, batch_size='day', microbatch_use_dynamic_overwrite=true) }}
 {{ config(materialized='materialized_view') }}
 {{ config(materialized='materialized_view', properties={"storage_medium":"SSD"}) }}
 {{ config(materialized='materialized_view', refresh_method="ASYNC START('2022-09-01 10:00:00') EVERY (interval 1 day)") }}

--- a/dbt/adapters/starrocks/__version__.py
+++ b/dbt/adapters/starrocks/__version__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.8.0"
+version = "1.9.0"

--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -42,6 +42,7 @@ class StarRocksConfig(AdapterConfig):
     distributed_by: Optional[List[str]] = None
     buckets: Optional[int] = None
     properties: Optional[Dict[str, str]] = None
+    microbatch_use_dynamic_overwrite: Optional[bool] = None
 
 
 class StarRocksAdapter(SQLAdapter):
@@ -180,7 +181,7 @@ class StarRocksAdapter(SQLAdapter):
 
     @override
     def valid_incremental_strategies(self):
-        return ["default", "insert_overwrite", "dynamic_overwrite"]
+        return ["default", "insert_overwrite", "dynamic_overwrite", "microbatch"]
 
 
 def _catalog_filter_schemas(used_schemas: FrozenSet[Tuple[str, str]]) -> Callable[[agate.Row], bool]:

--- a/dbt/include/starrocks/macros/adapters/relation.sql
+++ b/dbt/include/starrocks/macros/adapters/relation.sql
@@ -15,16 +15,11 @@
  */
 
 {% macro starrocks__drop_relation(relation) -%}
-  {%- set relation_type = relation.type %}
-  {%- if not relation_type or relation_type is none %}
-      {%- set relation_type = 'table' %}
-  {%- endif %}
-
   {% call statement('drop_relation', auto_begin=False) %}
     {%- if relation.is_materialized_view -%}
         drop materialized view if exists {{ relation }};
     {%- else -%}
-        drop {{ relation_type }} if exists {{ relation }};
+        drop {{ relation.type }} if exists {{ relation }};
     {%- endif -%}
   {% endcall %}
 {%- endmacro %}
@@ -52,15 +47,7 @@
 {%- endmacro %}
 
 {% macro starrocks__exchange_relation(first_relation, second_relation) -%}
-  {%- if second_relation.is_view %}
-    {%- set from_results = run_query('show create view ' + first_relation.render() ) %}
-    {%- set to_results = run_query('show create view ' + second_relation.render() ) %}
-    {%- call statement('exchange_view_relation') %}
-        alter view {{ relation1 }} as {{ to_results[0]['Create View'].split('AS',1)[1] }}
-    {%- endcall %}
-  {%- else %}
-    {%- call statement('exchange_relation') %}
-        alter table {{ first_relation }} swap with `{{ second_relation.table }}`;
-    {%- endcall %}
-  {%- endif %}
+  {%- call statement('exchange_relation') %}
+      alter table {{ first_relation }} swap with `{{ second_relation.table }}`;
+  {%- endcall %}
 {%- endmacro %}

--- a/dbt/include/starrocks/macros/adapters/relation.sql
+++ b/dbt/include/starrocks/macros/adapters/relation.sql
@@ -15,11 +15,16 @@
  */
 
 {% macro starrocks__drop_relation(relation) -%}
+  {%- set relation_type = relation.type %}
+  {%- if not relation_type or relation_type is none %}
+      {%- set relation_type = 'table' %}
+  {%- endif %}
+
   {% call statement('drop_relation', auto_begin=False) %}
     {%- if relation.is_materialized_view -%}
         drop materialized view if exists {{ relation }};
     {%- else -%}
-        drop {{ relation.type }} if exists {{ relation }};
+        drop {{ relation_type }} if exists {{ relation }};
     {%- endif -%}
   {% endcall %}
 {%- endmacro %}
@@ -44,4 +49,18 @@
       {{ exceptions.raise_compiler_error(msg) }}
     {% endif %}
   {% endcall %}
+{%- endmacro %}
+
+{% macro starrocks__exchange_relation(first_relation, second_relation) -%}
+  {%- if second_relation.is_view %}
+    {%- set from_results = run_query('show create view ' + first_relation.render() ) %}
+    {%- set to_results = run_query('show create view ' + second_relation.render() ) %}
+    {%- call statement('exchange_view_relation') %}
+        alter view {{ relation1 }} as {{ to_results[0]['Create View'].split('AS',1)[1] }}
+    {%- endcall %}
+  {%- else %}
+    {%- call statement('exchange_relation') %}
+        alter table {{ first_relation }} swap with `{{ second_relation.table }}`;
+    {%- endcall %}
+  {%- endif %}
 {%- endmacro %}

--- a/dbt/include/starrocks/macros/materializations/models/incremental.sql
+++ b/dbt/include/starrocks/macros/materializations/models/incremental.sql
@@ -14,37 +14,127 @@
  * limitations under the License.
  */
 
-{% macro get_incremental_insert_overwrite_sql(arg_dict) %}
-      {% do return(get_insert_overwrite_into_sql(arg_dict["target_relation"], arg_dict["temp_relation"], arg_dict["dest_columns"])) %}
-{% endmacro %}
+{%- macro get_incremental_insert_overwrite_sql(arg_dict) -%}
+    {%- do return(get_insert_overwrite_into_sql(arg_dict["target_relation"], arg_dict["temp_relation"], arg_dict["dest_columns"])) -%}
+{%- endmacro -%}
 
-{% macro get_incremental_dynamic_overwrite_sql(arg_dict) %}
-      {% do return(get_dynamic_overwrite_into_sql(arg_dict["target_relation"], arg_dict["temp_relation"], arg_dict["dest_columns"])) %}
-{% endmacro %}
+{%- macro get_incremental_dynamic_overwrite_sql(arg_dict) -%}
+    {%- do return(get_dynamic_overwrite_into_sql(arg_dict["target_relation"], arg_dict["temp_relation"], arg_dict["dest_columns"])) -%}
+{%- endmacro -%}
 
-{% macro _get_strategy_sql(target_relation, temp_relation, dest_cols_csv, is_dynamic_overwrite) %}
-    {% set overwrite_type = "TRUE" if is_dynamic_overwrite else "FALSE" %}
+{%- macro starrocks__get_incremental_microbatch_sql(arg_dict) -%}
+    {%- set microbatch_use_dynamic_overwrite = config.get('microbatch_use_dynamic_overwrite') or False -%}
+    {%- if microbatch_use_dynamic_overwrite -%}
+        {%- do return(get_incremental_dynamic_overwrite_sql(arg_dict)) -%}
+    {%- else -%}
+        {%- do return(get_incremental_insert_overwrite_sql(arg_dict)) -%}
+    {%- endif -%}
+{%- endmacro -%}
 
-    insert /*+SET_VAR(dynamic_overwrite = {{ overwrite_type }})*/ overwrite {{ target_relation }}({{ dest_cols_csv }})
+{%- macro _get_strategy_sql(target_relation, temp_relation, dest_cols_csv, is_dynamic_overwrite) -%}
+    {%- set overwrite_type = "TRUE" if is_dynamic_overwrite else "FALSE" %}
+
+    insert overwrite /*+SET_VAR(dynamic_overwrite = {{ overwrite_type }})*/ {{ target_relation }}({{ dest_cols_csv }})
     (
         select {{ dest_cols_csv }}
         from {{ temp_relation }}
     )
-{% endmacro %}
+{%- endmacro -%}
 
-{% macro get_insert_overwrite_into_sql(target_relation, temp_relation, dest_columns) %}
+{%- macro get_insert_overwrite_into_sql(target_relation, temp_relation, dest_columns) -%}
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     {%- do return(_get_strategy_sql(target_relation, temp_relation, dest_cols_csv, false)) -%}
-{% endmacro %}
+{%- endmacro -%}
 
-{% macro get_dynamic_overwrite_into_sql(target_relation, temp_relation, dest_columns) %}
-    {% if adapter.is_before_version("3.4.0") %}
+{%- macro get_dynamic_overwrite_into_sql(target_relation, temp_relation, dest_columns) -%}
+    {%- if adapter.is_before_version("3.4.0") -%}
         {%- set msg -%}
             [dynamic_overwrite] is only available from version 3.4.0 onwards, current version is {{ adapter.current_version() }}
         {%- endset -%}
         {{ exceptions.raise_compiler_error(msg) }}
-    {% else %}
+    {%- else -%}
         {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
         {%- do return(_get_strategy_sql(target_relation, temp_relation, dest_cols_csv, true)) -%}
-    {% endif %}
-{% endmacro %}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- materialization incremental, adapter='starrocks' -%}
+    {%- set keys = config.get('keys', validator=validation.any[list]) -%}
+    {%- set full_refresh_mode = (should_full_refresh()) -%}
+    {%- set identifier = this.name -%}
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier,
+        schema=schema,
+        database=database,
+        type='table',
+    ) -%}
+    {%- set existing_relation = load_relation(this) -%}
+    {%- set incremental_strategy = starrocks__validate_get_incremental_strategy(config) -%}
+    {%- set tmp_relation = make_temp_relation(this).incorporate(type='table') -%}
+
+    {{ drop_relation_if_exists(tmp_relation) }}
+
+    {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
+
+    {{ run_hooks(pre_hooks) }}
+
+    {%- if existing_relation is none -%}
+        {%- call statement('main') -%}
+            {{ starrocks__create_table_as(False, target_relation, compiled_code) }}
+        {%- endcall -%}
+
+    {%- elif existing_relation.is_view -%}
+        {#-- Can't overwrite a view with a table, drop it before creating table --#}
+        {{ log("Dropping relation " ~ target_relation ~ " because it is a view and this model is a table.") }}
+        {%- do adapter.drop_relation(existing_relation) -%}
+        {%- call statement('main') -%}
+            {{ starrocks__create_table_as(False, target_relation, compiled_code) }}
+        {%- endcall -%}
+
+    {%- elif full_refresh_mode -%}
+        {#-- First create a backup of the existing table and then exchange the new table with the backup --#}
+        {%- set backup_identifier = existing_relation.identifier ~ "__dbt_backup" -%}
+        {%- set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) -%}
+        {%- do adapter.drop_relation(backup_relation) -%}
+        {%- call statement('main') -%}
+            {{ starrocks__create_table_as(False, backup_relation, compiled_code) }}
+        {%- endcall -%}
+        {%- do starrocks__exchange_relation(target_relation, backup_relation) -%}
+    {% else %}
+        {#-- Create the temp relation, either as a view or as a temp table --#}
+        {%- call statement('create_tmp_relation') -%}
+            {{ starrocks__create_table_as(True, tmp_relation, compiled_code) }}
+        {%- endcall -%}
+
+        {%- do adapter.expand_target_column_types(
+            from_relation=tmp_relation,
+            to_relation=target_relation
+        ) -%}
+        {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
+        {%- set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) -%}
+        {%- if not dest_columns %}
+            {%- set dest_columns = adapter.get_columns_in_relation(existing_relation) -%}
+        {%- endif -%}
+
+        {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}
+        {%- set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) -%}
+        {%- set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) -%}
+        {%- set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': tmp_relation, 'unique_key': keys, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) -%}
+
+        {%- call statement('main') -%}
+            {{ strategy_sql_macro_func(strategy_arg_dict) }}
+        {%- endcall -%}
+    {%- endif -%}
+
+    {%- do drop_relation_if_exists(tmp_relation) -%}
+
+    {{ run_hooks(post_hooks) }}
+
+    {%- set target_relation = target_relation.incorporate(type='table') -%}
+
+    {%- set should_revoke = should_revoke(existing_relation.is_table, full_refresh_mode) -%}
+    {%- do apply_grants(target_relation, grant_config, should_revoke=should_revoke) -%}
+    {%- do persist_docs(target_relation, model) -%}
+
+    {{ return({'relations': [target_relation]}) }}
+{%- endmaterialization -%}

--- a/dbt/include/starrocks/macros/materializations/models/incremental_strategy.sql
+++ b/dbt/include/starrocks/macros/materializations/models/incremental_strategy.sql
@@ -1,0 +1,24 @@
+{%- macro starrocks__validate_microbatch_config(config) -%}
+    {%- set required_config_keys = ['event_time', 'begin', 'batch_size'] -%}
+    {%- for key in required_config_keys -%}
+        {%- if not config.get(key) -%}
+            {%- do exceptions.raise_compiler_error("The 'microbatch' incremental strategy requires the '" ~ key ~ "' configuration to be set.") -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+
+{%- macro starrocks__validate_get_incremental_strategy(config) -%}
+    {%- set strategy = config.get('incremental_strategy') or 'default' -%}
+    {%- set invalid_strategy_msg -%}
+        Invalid incremental strategy provided: {{ strategy }}
+        Expected one of: 'default', 'insert_overwrite', 'dynamic_overwrite', 'microbatch'
+    {%- endset -%}
+    {%- if strategy not in ['default', 'insert_overwrite', 'dynamic_overwrite', 'microbatch'] -%}
+        {%- do exceptions.raise_compiler_error(invalid_strategy_msg) -%}
+    {%- endif -%}
+
+    {%- if strategy == 'microbatch' -%}
+        {%- do starrocks__validate_microbatch_config(config) -%}
+    {%- endif -%}
+    {%- do return (strategy) -%}
+{%- endmacro -%}

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     include_package_data=True,
     install_requires=[
-        "dbt-core>=1.8.0",
+        "dbt-core>=1.9.0",
         "mysql-connector-python>=8.1",
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(os.path.join(this_directory, "README.md"), encoding='utf-8') as f:
 
 package_name = "dbt-starrocks"
 # make sure this always matches dbt/adapters/starrocks/__version__.py
-package_version = "1.8.0"
+package_version = "1.9.0"
 description = """The Starrocks adapter plugin for dbt"""
 
 
@@ -57,7 +57,7 @@ setup(
     packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     include_package_data=True,
     install_requires=[
-        "dbt-core~=1.8.0",
+        "dbt-core>=1.8.0",
         "mysql-connector-python>=8.1",
     ],
     zip_safe=False,

--- a/tests/functional/adapter/test_incremental.py
+++ b/tests/functional/adapter/test_incremental.py
@@ -61,11 +61,11 @@ class TestBaseIncrementalStrategyModel(ABC, BaseIncremental):
     @staticmethod
     @abstractmethod
     def _get_strategy():
-        raise NotImplemented
+        raise NotImplementedError
 
     @abstractmethod
     def _specific_assertions(self, project):
-        raise NotImplemented
+        raise NotImplementedError
 
     @staticmethod
     def _seeds():


### PR DESCRIPTION
## Context

`dbt-core` from version `1.9.0` introduces new incremental strategy called `microbatch.` When dbt runs a microbatch model — whether for the first time, during incremental runs, or in specified backfills — it will split the processing into multiple queries (or **batches**).

![image](https://github.com/user-attachments/assets/d53fb08f-f5c2-4c74-a1c8-0a5a5838a939).

This PR is therefore about contributing a new option to use `microbatch` in `dbt-starrocks` adapter.

## Usage

When using `dbt-starrocks` with the new `microbatch` incremental strategy, we must specify three dbt model configurations: `event_time`, `begin` and `batch_size`. Other configurations like `lookback`, `concurrent_batches` or `microbatch_use_dynamic_overwrite` are optional.

Example:

```sql
{{
    config(
        materialized = 'incremental',
        incremental_strategy = 'microbatch',
        event_time = 'report_day',
        begin = '2025-01-01',
        lookback = 1,
        batch_size = 'day',
        microbatch_use_dynamic_overwrite = true
    )
}}
```

## Contribution

- Add materialization `incremental` that supports all `incremental_strategy` includes `default`, `insert_overwrite`, `dynamic_overwrite` and `microbatch`.
- Update the README.md documentation.