### PR TITLE
Add submittable ETL task

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ models:
   // Expr partition type requires an expression (e.g., date_trunc) specified in partition_by
   order_by: ['some_column']             // only for PRIMARY table_type
   partition_type: 'RANGE'               // RANGE or LIST or Expr Need to be used in combination with partition_by configuration
-  properties: [{"replication_num":"1", "in_memory": "true"}]
+  properties: {"replication_num":"1", "in_memory": "true"}
   refresh_method: 'async'               // only for materialized view default manual
   
   // For 'materialized=incremental' in version >= 3.4

--- a/dbt/adapters/starrocks/__version__.py
+++ b/dbt/adapters/starrocks/__version__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.8.0"
+version = "1.9.0"

--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -45,6 +45,8 @@ class StarRocksCredentials(Credentials):
     charset: Optional[str] = None
     version: Optional[str] = None
     use_pure: Optional[str] = None
+    is_async: Optional[bool] = False
+    async_query_timeout: Optional[int] = 300
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
@@ -82,6 +84,8 @@ class StarRocksCredentials(Credentials):
             "catalog",
             "username",
             "use_pure",
+            "is_async",
+            "async_query_timeout",
         )
 
 

--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -12,15 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
+import time
+import uuid
 from concurrent.futures import Future
-from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple
+from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple, TypeAlias
 
 import agate
 import dbt.exceptions
 from dbt.adapters.base import available
 from dbt.adapters.base.impl import _expect_row_value, catch_as_completed
 from dbt.adapters.base.relation import InformationSchema
+from dbt.adapters.contracts.connection import AdapterResponse
+from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.protocol import AdapterConfig
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.sql.impl import LIST_RELATIONS_MACRO_NAME, LIST_SCHEMAS_MACRO_NAME
@@ -32,6 +36,14 @@ from dbt.adapters.starrocks.column import StarRocksColumn
 from dbt.adapters.starrocks.connections import StarRocksConnectionManager
 from dbt.adapters.starrocks.relation import StarRocksRelation
 
+
+logger = AdapterLogger("starrocks")
+
+SQLQueryResult: TypeAlias = Tuple[AdapterResponse, "agate.Table"]
+
+MAX_POLL_DELAY = 600  # 10 minutes
+SUBMIT_TASK_TEMPLATE = "submit /*+set_var(query_timeout={timeout})*/ task {task_id} as {sql}"
+POLL_TASK_TEMPLATE = "select * from information_schema.task_runs where task_name = '{task_id}'"
 
 class StarRocksConfig(AdapterConfig):
     engine: Optional[str] = None
@@ -49,6 +61,149 @@ class StarRocksAdapter(SQLAdapter):
     Relation = StarRocksRelation
     AdapterSpecificConfigs = StarRocksConfig
     Column = StarRocksColumn
+
+    @staticmethod
+    def _is_submittable_etl(sql: str) -> bool:
+        """
+        Evaluates if the SQL statement matches supported StarRocks ETL patterns.
+
+        Supported patterns:
+        - CREATE TABLE ... SELECT
+        - INSERT INTO/OVERWRITE
+        - CACHE SELECT
+
+        Reference: https://docs.starrocks.io/docs/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK/
+
+        :param sql: The SQL statement to evaluate.
+        :return: True or False depending on whether the SQL statement is a submittable ETL.
+        """
+        # Remove newlines and normalize whitespace
+        sql_clean = sql.strip().replace('\n', '')
+        sql_clean = re.sub(r'\s+', ' ', sql_clean).strip().lower()
+
+        # Note: # Supported ETL patterns from StarRocks documentation
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK/
+        #
+        # The goal here is to soft-match the ETL patterns for dbt-generated sql queries.
+        # It is not intended to be exhaustive nor to validate SQL statement, this will be left to the engine.
+        suitable_etl_patterns = [
+            r'^create\s+table.*select',
+            r'^insert\s+(into|overwrite)\b',
+            r'^cache\s+select\b'
+        ]
+
+        return any(re.search(pattern, sql_clean) for pattern in suitable_etl_patterns)
+
+    def _poll_for_complete_task(self, task_id: str) -> SQLQueryResult:
+        """
+        Polls for the completion of a task.
+
+        :param task_id: The task ID to poll for.
+        :return: A tuple of the execution status and polling results.
+        """
+        _poll_sql = POLL_TASK_TEMPLATE.format(task_id=task_id)
+        _connection = self.connections.get_if_exists() or self.connections.begin()
+        _attempts = 1
+
+        while True:
+
+            # Open if needed
+            self.connections.open(_connection)
+
+            # Get the status from task_runs
+            response, table = super().execute(sql=_poll_sql, fetch=True, limit=1)
+            if response.code != 'SUCCESS':
+                logger.error(
+                    f"Error: Could not poll task [{task_id}]. "
+                    f"Reason: failed with response.code: [{response.code}]"
+                )
+                return response, table
+
+            # Check if we got any results
+            if not table or len(table) == 0:
+                logger.info(f"Task {task_id} not found. Aborting...")
+                return response, table
+
+            # Validate status
+            status = table[0].get("STATE", "unknown")
+            if status == "FAILED":
+                _error_msg = table[0].get("ERROR_MESSAGE", "")
+                logger.error(f"Task [{task_id}] failed with status [{status}] and error message: {_error_msg}")
+                return response, table
+
+            elif status in ["SUCCESS", "MERGED", "unknown"]:
+                logger.info(f"Task [{task_id}] finished with status [{status}]")
+                return response, table
+
+            # Compute next delay
+            poll_delay = min(MAX_POLL_DELAY, 2 ** _attempts)
+            _attempts += 1
+
+            # Notify end user
+            progress = table[0].get("PROGRESS", "unknown")
+            logger.info(f"Task {task_id} progress [{progress}]. Waiting {poll_delay} seconds...")
+
+            # Close connection before sleeping to avoid stale connections
+            self.connections.close(_connection)
+            time.sleep(poll_delay)
+
+    def _execute_async_task(self, sql: str, auto_begin: bool = False, fetch: bool = False, limit: Optional[int] = None) -> SQLQueryResult:
+        """
+        Executes an SQL statement asynchronously and wait for completion.
+
+        :param str sql: The sql to execute.
+        :param bool auto_begin: If set, and dbt is not currently inside a
+            transaction, automatically begin one.
+        :param bool fetch: If set, fetch results.
+        :param Optional[int] limit: If set, only fetch n number of rows
+        :return: A tuple of the query status and results (empty if fetch=False).
+        :rtype: Tuple[AdapterResponse, "agate.Table"]
+        """
+        _task_id = str(uuid.uuid4()).replace('-', '')
+        _timeout = self.config.credentials.async_query_timeout
+
+        _submit_sql = SUBMIT_TASK_TEMPLATE.format(
+            timeout=_timeout,
+            task_id=_task_id,
+            sql=sql,
+        )
+
+        super().execute(
+            sql=_submit_sql,
+            auto_begin=auto_begin,
+            fetch=fetch,
+            limit=limit
+        )
+        return self._poll_for_complete_task(_task_id)
+
+    @override
+    def execute(
+        self,
+        sql: str,
+        auto_begin: bool = False,
+        fetch: bool = False,
+        limit: Optional[int] = None,
+    ) -> SQLQueryResult:
+        """
+        Execute a SQL statement against the database.
+
+        This method overrides the base class method to support submittable ETL.
+
+        Only if the adapter is configured to be async:
+        - it will intercept the original SQL statement and prefix it with a `submit task` statement if the SQL is a submittable ETL
+        - it will then poll the task status until the task is completed using basic exponential backoff
+
+        :param str sql: The sql to execute.
+        :param bool auto_begin: If set, and dbt is not currently inside a
+            transaction, automatically begin one.
+        :param bool fetch: If set, fetch results.
+        :param Optional[int] limit: If set, only fetch n number of rows
+        :return: A tuple of the query status and results (empty if fetch=False).
+        :rtype: Tuple[AdapterResponse, "agate.Table"]
+        """
+        if not self.config.credentials.is_async or not self._is_submittable_etl(sql):
+            return super().execute(sql=sql, auto_begin=auto_begin, fetch=fetch, limit=limit)
+        return self._execute_async_task(sql=sql, auto_begin=auto_begin, fetch=fetch, limit=limit)
 
     @classmethod
     def date_function(cls) -> str:

--- a/dbt/include/starrocks/macros/adapters/relation_helpers.sql
+++ b/dbt/include/starrocks/macros/adapters/relation_helpers.sql
@@ -37,8 +37,6 @@
 
   {%- if properties is none -%}
         {%- set properties = config.get('properties', {"replication_num":"1"}) -%}
-  {%- else -%}
-        {%- set properties = fromjson(config.get('properties')) -%}
   {%- endif -%}
 
   {# 1. SET ENGINE #}

--- a/dbt/include/starrocks/macros/materializations/models/table.sql
+++ b/dbt/include/starrocks/macros/materializations/models/table.sql
@@ -18,6 +18,7 @@
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set engine = config.get('engine', 'OLAP') -%}
   {%- set indexs = config.get('indexs') -%}
+  {%- set properties = config.get('properties') -%}
 
   {{ sql_header if sql_header is not none }}
 
@@ -39,6 +40,12 @@
     {%- endset %}
     {{ exceptions.raise_compiler_error(msg) }}
   {%- endif -%}
+
+  {% if properties is not none %}
+     PROPERTIES (
+        {{ properties }}
+     )
+  {% endif %}
 
   as {{ sql }}
 

--- a/dbt/include/starrocks/macros/materializations/models/table.sql
+++ b/dbt/include/starrocks/macros/materializations/models/table.sql
@@ -41,12 +41,6 @@
     {{ exceptions.raise_compiler_error(msg) }}
   {%- endif -%}
 
-  {% if properties is not none %}
-     PROPERTIES (
-        {{ properties }}
-     )
-  {% endif %}
-
   as {{ sql }}
 
 {%- endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(os.path.join(this_directory, "README.md"), encoding='utf-8') as f:
 
 package_name = "dbt-starrocks"
 # make sure this always matches dbt/adapters/starrocks/__version__.py
-package_version = "1.8.0"
+package_version = "1.9.0"
 description = """The Starrocks adapter plugin for dbt"""
 
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -10,10 +10,47 @@ from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
+from dbt.tests.util import (
+    check_relation_types,
+    check_relations_equal,
+    check_result_nodes_by_name,
+    relation_from_name,
+    run_dbt,
+)
+
+base_table_model_with_props_sql = """
+{{ 
+    config(
+        materialized = 'table', 
+        engine='OLAP', 
+        distributed_by=['id'], 
+        buckets="2 ",
+        properties={"replication_num":"1", 'colocate_with': 'cg1'}
+    ) 
+}}
+select * from {{ ref('base') }}
+""".lstrip()
+
+create_table_with_props_sql = """
+CREATE TABLE `table_model_with_props` (
+  `id` int(11) NULL COMMENT "",
+  `name` varchar(65533) NULL COMMENT "",
+  `some_date` datetime NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`, `name`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 2 
+PROPERTIES (
+"colocate_with" = "cg1",
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+""".replace("\n", "").replace(" ", "")
 
 # StarRocks doesn't support materialization from table to view https://github.com/StarRocks/dbt-starrocks/issues/33
 class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
-    @pytest.fixture(scope="class")
+
     def test_base(self, project):
 
         # seed command
@@ -69,7 +106,27 @@ class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
         }
         check_relation_types(project.adapter, expected)
 
-    pass
+class TestSimpleMaterializationWithProperties(BaseSimpleMaterializations):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model_with_props.sql": base_table_model_with_props_sql,
+        }
+
+    def test_base(self, project):
+        results = run_dbt(["seed"])
+        # seed result length
+        assert len(results) == 1
+
+        # run command
+        results = run_dbt(["run"])
+        # run result length
+        assert len(results) == 1
+
+        relation = results[0].node.relation_name
+        result = project.run_sql(f"SHOW CREATE TABLE {relation}", fetch="one")[1]
+        assert result.replace(' ', '').replace('\n', '') == create_table_with_props_sql
 
 
 class TestSingularTestsMyAdapter(BaseSingularTests):

--- a/tests/functional/adapter/test_submit_task.py
+++ b/tests/functional/adapter/test_submit_task.py
@@ -1,0 +1,86 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture, check_relations_equal, relation_from_name
+
+
+seed_a_csv = """
+id,value
+1,a
+2,b
+3,c
+4,d
+5,e
+""".lstrip()
+
+model_a_csv = """
+{{ config(materialized='table') }}
+
+select *, SLEEP(1) from {{ ref('seed_a') }}
+""".lstrip()
+
+@pytest.fixture(scope="class")
+def dbt_profile_target():
+    return {
+        'type': 'starrocks',
+        'username': 'root',
+        'password': '',
+        'port': 9030,
+        'host': 'localhost',
+        'is_async': True,
+        'async_query_timeout': 10,
+    }
+
+class TestSubmitTaskModel:
+
+    @staticmethod
+    def _seeds():
+        return {
+            "seed_a.csv": seed_a_csv,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "test_submit_task",
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return self._seeds()
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_a.sql": model_a_csv,
+        }
+
+    def _seed_assertions(self, project):
+        _seeds_row_counts = [
+            ("seed_a", 5),
+        ]
+
+        # seed command
+        results = run_dbt(["seed"])
+        assert len(results) == len(_seeds_row_counts)
+
+        # Make sure seeds are properly setup
+        for pname, pcount in _seeds_row_counts:
+            relation = relation_from_name(project.adapter, f"{pname}")
+            result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+            assert result[0] == pcount
+
+
+    def _doc_tests(self):
+        # get catalog from docs generate
+        catalog = run_dbt(["docs", "generate"])
+        assert len(catalog.nodes) == len(self._seeds()) + 1
+
+    def test_submit_task(self, project):
+        self._seed_assertions(project=project)
+
+        results, stdout = run_dbt_and_capture(["run", "--select", "model_a"])
+        assert len(results) == 1
+        assert "Waiting 4 seconds..." in stdout
+        check_relations_equal(project.adapter, ["seed_a", "model_a"])
+
+        self._doc_tests()

--- a/tests/unit/test_submit_task.py
+++ b/tests/unit/test_submit_task.py
@@ -1,0 +1,45 @@
+import pytest
+from dbt.adapters.starrocks.impl import StarRocksAdapter
+
+
+class TestDBTLikeIsSubmittableETL:
+    @pytest.mark.parametrize(
+        "sql, expected",
+        [
+            # DBT-like statements
+            (
+                """ create table `my_db`.`my_table`
+                PRIMARY KEY (key1, key2, key3) PARTITION BY (`key1`)
+                DISTRIBUTED BY HASH (another_key) BUCKETS 5 as 
+                PROPERTIES (
+                  "replication_num" = "1"
+                )
+                as with source as (
+                    select * from `my_db`.`my_table`
+                ),
+                renamed as (
+                    select
+                        *
+                    from source
+                )
+                select * from renamed
+                """, True
+            ),
+            (
+                """
+                insert into `my_table`.`my_db` (`id`, `value`) values
+                (%s,%s),(%s,%s),(%s,%s),(%s,%s)
+                """,
+                True
+            ),
+            (
+                """
+                cache select   *
+                from `my_table`.`my_db`
+                """,
+                True
+            ),
+        ]
+    )
+    def test_is_submittable_etl_suitable(self, sql, expected):
+        assert StarRocksAdapter._is_submittable_etl(sql) == expected


### PR DESCRIPTION
# Context

When running dbt jobs, some models can take up quite a bit of time to build and we need to make sure that we are not keeping connections open while those big models are being built. This is especially true in a distributed system scenario where the dbt runner and the StarRocks clusters are on different networks. 

StarRocks support the submission of ETL tasks. (https://docs.starrocks.io/docs/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK/) 

We therefore need to enable this feature in the `dbt-starrocks` plugin. 

# Contribution

## Submittable ETL tasks

> The implementation of the submittable etl is located in the `impl.py` file.

Setting `is_async: true` in your `profiles.yml` will enable submitting suitable ETL tasks using the `submit task` feature of StarRocks.

This will be automatically wrapped around any statement that supports submission. Setting this manually is currently not supported by the adapter.

The following statements will be submitted automatically:

- `CREATE AS ... SELECT`
- `INSERT INTO|OVERWRITE`
- `CACHE SELECT ...`

> See [StarRocks' documentation on SUBMIT TASK](https://docs.starrocks.io/docs/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK/)
### Task Polling

Once the task has been submitted, the adapter will periodically poll StarRocks' `information_schema.task_runs` to retrieve the task status. 

The polling is implemented using an exponential backoff, with a maximum delay of 10 minutes. The adapter's connection to the StarRocks' cluster will not be maintained during the waiting period. It will be re-opened right before the next status polling phase.

### Controlling the task timeout

Using the `async_query_timeout` property in the `profiles.yml` will control the value of the `query_timeout` when submitting task.

It's going to be injected in the SQL query submitted to StarRocks:

```sql
submit /*+set_var(query_timeout={async_query_timeout})*/ task ...
```

### Example `profiles.yml` configuration

```yml
my_profile:
  target: dev
  outputs:
    dev:
      type: starrocks
      host: host
      port: 9030
      schema: schema
      username: username
      password: password
      is_async: true
      async_query_timeout: 3600 # 1 hour
```

---

### Extra details on the behaviour

The new behaviour is controlled by a new `is_async` property that should be added to the `profiles.yml` configuration. 

- If `is_async!=true`: Standard scenario, we passthrough to `super().execute(...)`
- If `is_async==true`: Asynchronous scenario, where we add a `submit task` statement before the SQL query itself and poll until completion. 

The following sequence diagram represents (at the conceptual level) what is the relationship between the new adapter methods:

![image](https://github.com/user-attachments/assets/d66521d7-befc-42d8-8559-af5160bc6990)

---

### Additional contribution / Scope Creep

Currently, the `README.md` documentation contains 2 different ways of setting `properties`:
- `properties: [{"replication_num":"1", "in_memory": "true"}]`
- `properties={"storage_medium":"SSD"}` 

For `OLAP` tables, this will yield the following error: 

```
  the JSON object must be str, bytes or bytearray, not dict
  
  > in macro starrocks__create_table_as (macros/materializations/models/table.sql)
  > called by macro create_table_as (macros/relations/table/create.sql)
  > called by macro default__get_create_table_as_sql (macros/relations/table/create.sql)
  > called by macro get_create_table_as_sql (macros/relations/table/create.sql)
  > called by macro statement (macros/etc/statement.sql)
  > called by macro materialization_table_default (macros/materializations/models/table.sql)
  > called by model table_model_with_props (models/table_model_with_props.sql)
```

The root cause of this error is the usage of `fromjson` which expects a  string to deserialize ([Ref](https://docs.getdbt.com/reference/dbt-jinja-functions/fromjson)). Which is not the type of object being returned by the following code in `relation_helpers.sql`: 

```
{%- set properties = config.get('properties') -%}
```

**Solution:**

- Document the `properties` type as only dictionary in the `README.md` 
- Remove the `else` condition calling the `fromjson` 
- Add a test case to make sure the table is created with the expected `properties` 