### PR TITLE
[BugFix]Fix Python 3.9.x compatibility problem

### DIFF
--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -16,7 +16,8 @@ import re
 import time
 import uuid
 from concurrent.futures import Future
-from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple, TypeAlias
+from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple
+from typing_extensions import TypeAlias
 
 import agate
 import dbt.exceptions


### PR DESCRIPTION
## Why I'm doing:
**Since Python 3.10, TypeAlias annotations are available in the typing module.**
1. When I tried to use the Python 3.9 environment to try running the DBT Getting Started Sample Project (Jaffle Shop) with DBt-Starrocks, the environment showed an error, indicates that the dbt-starrocks plugin is not recognized correctly:
```SH
(dbt-env) root@f4c62d73d543:/jaffle-shop-classic# dbt --version
Core:
  - installed: 1.9.3
  - latest:    1.9.3 - Up to date!

Plugins: 
!!! The plug-in version does not show anything
```
```SH
(dbt-env) root@f4c62d73d543:/jaffle-shop-classic# python -c "import dbt.adapters.starrocks; print(dbt.adapters.starrocks)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/dbt-env/lib/python3.9/site-packages/dbt/adapters/starrocks/__init__.py", line 17, in <module>
    from dbt.adapters.starrocks.impl import StarRocksAdapter
  File "/dbt-env/lib/python3.9/site-packages/dbt/adapters/starrocks/impl.py", line 19, in <module>
    from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple, TypeAlias
ImportError: cannot import name 'TypeAlias' from 'typing' (/usr/local/lib/python3.9/typing.py)
```
## What I'm doing:
Change imp.py to typing_extensions instead of typing:
```py
from typing_extensions import TypeAlias
```
Fixes #65 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.