### PR TITLE
adjust sql hint position for incremental materialization

### DIFF
--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -16,7 +16,8 @@ import re
 import time
 import uuid
 from concurrent.futures import Future
-from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple, TypeAlias
+from typing import Callable, Dict, List, Optional, Set, FrozenSet, Tuple
+from typing_extensions import TypeAlias
 
 import agate
 import dbt.exceptions

--- a/dbt/include/starrocks/macros/materializations/models/incremental.sql
+++ b/dbt/include/starrocks/macros/materializations/models/incremental.sql
@@ -34,7 +34,7 @@
 {%- macro _get_strategy_sql(target_relation, temp_relation, dest_cols_csv, is_dynamic_overwrite) -%}
     {%- set overwrite_type = "TRUE" if is_dynamic_overwrite else "FALSE" %}
 
-    insert overwrite /*+SET_VAR(dynamic_overwrite = {{ overwrite_type }})*/ {{ target_relation }}({{ dest_cols_csv }})
+    insert /*+SET_VAR(dynamic_overwrite = {{ overwrite_type }})*/ overwrite {{ target_relation }} ({{ dest_cols_csv }})
     (
         select {{ dest_cols_csv }}
         from {{ temp_relation }}


### PR DESCRIPTION
The SQL hint in `INSERT` statement for Incremental materialization is put behind the `overwrite` keyword, which will not take effect as expected even if `dynamic_overwrite` is set to true.