### PR TITLE
Add auth_plugin parameter to dbt-starrocks

### DIFF
--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -47,7 +47,8 @@ class StarRocksCredentials(Credentials):
     use_pure: Optional[str] = None
     is_async: Optional[bool] = False
     async_query_timeout: Optional[int] = 300
-
+    auth_plugin: Optional[str] = ''
+    
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -86,6 +87,7 @@ class StarRocksCredentials(Credentials):
             "use_pure",
             "is_async",
             "async_query_timeout",
+            "auth_plugin",
         )
 
 
@@ -115,7 +117,7 @@ class StarRocksConnectionManager(SQLConnectionManager):
 
         credentials = cls.get_credentials(connection.credentials)
         kwargs = {"host": credentials.host, "username": credentials.username,
-                  "password": credentials.password, "database": credentials.catalog + "." + credentials.schema}
+                  "password": credentials.password, "database": credentials.catalog + "." + credentials.schema, "auth_plugin":credentials.auth_plugin}
 
         kwargs["buffered"] = True
 

--- a/dbt/include/starrocks/profile_template.yml
+++ b/dbt/include/starrocks/profile_template.yml
@@ -31,6 +31,9 @@ prompts:
     hint: 'password'
     hide_input: true
     default: ''
+  auth_plugin:
+    hint: 'If you are using LDAP authentication, you need change to mysql_clear_password.'
+    default: ''
   version:
     default: ''
 

--- a/dbt/include/starrocks/sample_profiles.yml
+++ b/dbt/include/starrocks/sample_profiles.yml
@@ -21,6 +21,7 @@ default:
       schema: <schema>
       username: <username>
       password: <password>
+      auth_plugin: <auth_plugin>  # optional
     prod:
       type: starrocks
       host: <host>
@@ -28,4 +29,5 @@ default:
       schema: <schema>
       username: <username>
       password: <password>
+      auth_plugin: <auth_plugin>  # optional
   target: dev


### PR DESCRIPTION
In StarRocks, when we are using LDAP authentication, we have to set the auth_plugin to mysql_clear_password. However, in dbt-starrocks didn't expose such parameter to config.

This PR is adding this kind of parameter, so that if user is using LDAP authentication, they will be able to set auth_plugin
to mysql_clear_password. And possible other authentication method in future.