### PR TITLE
Update metadata.sql

### DIFF
--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -20,7 +20,7 @@
       null as "database",
       tbl.table_name as name,
       tbl.table_schema as "schema",
-      case when tbl.table_type = 'BASE TABLE' then 'table'
+      case when tbl.table_type IN ('BASE TABLE', 'TABLE') then 'table'
            when tbl.table_type = 'VIEW' and mv.table_name is null then 'view'
            when tbl.table_type = 'VIEW' and mv.table_name is not null then 'materialized_view'
            when tbl.table_type = 'SYSTEM VIEW' then 'system_view'


### PR DESCRIPTION
Recent StarRocks versions (3.4+) report 'TABLE' instead of 'BASE TABLE' in information_schema. This caused dbt to misclassify tables as 'unknown', leading to a "DROP UNKNOWN" error on subsequent runs.

This change updates the catalog query to recognize both types, restoring compatibility.