### PR TITLE
Fix StarRocks Version Detection Error

### DIFF
--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -303,9 +303,8 @@ class StarRocksAdapter(SQLAdapter):
     @available
     def is_before_version(self, version: str) -> bool:
         conn = self.connections.get_if_exists()
-        if conn:
-            server_version = conn.handle.server_version
-            server_version_tuple = tuple(server_version)
+        if conn and hasattr(conn, 'starrocks_version'):
+            server_version_tuple = conn.starrocks_version
             version_detail_tuple = tuple(
                 int(part) for part in version.split(".") if part.isdigit())
             if version_detail_tuple > server_version_tuple:
@@ -315,8 +314,8 @@ class StarRocksAdapter(SQLAdapter):
     @available
     def current_version(self):
         conn = self.connections.get_if_exists()
-        if conn:
-            server_version = conn.handle.server_version
+        if conn and hasattr(conn, 'starrocks_version'):
+            server_version = conn.starrocks_version
             if server_version != (999, 999, 999):
                 return "{}.{}.{}".format(server_version[0], server_version[1], server_version[2])
         return 'UNKNOWN'

--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -20,7 +20,7 @@
       null as "database",
       tbl.table_name as name,
       tbl.table_schema as "schema",
-      case when tbl.table_type IN ('BASE TABLE', 'TABLE') then 'table'
+      case when tbl.table_type = 'BASE TABLE' then 'table'
            when tbl.table_type = 'VIEW' and mv.table_name is null then 'view'
            when tbl.table_type = 'VIEW' and mv.table_name is not null then 'materialized_view'
            when tbl.table_type = 'SYSTEM VIEW' then 'system_view'

--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -20,7 +20,7 @@
       null as "database",
       tbl.table_name as name,
       tbl.table_schema as "schema",
-      case when tbl.table_type = 'BASE TABLE' then 'table'
+      case when tbl.table_type IN ('BASE TABLE', 'TABLE') then 'table'
            when tbl.table_type = 'VIEW' and mv.table_name is null then 'view'
            when tbl.table_type = 'VIEW' and mv.table_name is not null then 'materialized_view'
            when tbl.table_type = 'SYSTEM VIEW' then 'system_view'


### PR DESCRIPTION
# Fix StarRocks Version Detection Error

## Problem

The dbt-starrocks adapter was failing with the following error during connection:
```
Got an error when obtain StarRocks version exception: 'property 'server_version' of 'CMySQLConnection' object has no setter'
```

This error occurred because the adapter was attempting to assign StarRocks version information to the MySQL connector's `server_version` property, which is read-only in recent versions of the mysql-connector-python library.

## Root Cause

1. **Read-only property**: The MySQL connector's `server_version` property is designed to be read-only and automatically populated during the MySQL protocol handshake
2. **Version format mismatch**: StarRocks returns version strings like `"3.4.3-a01aa59"` which differ from MySQL's expected format
3. **Parsing issues**: The existing `_parse_version()` function had bugs that prevented correct parsing of StarRocks version strings

## Solution

Instead of trying to override the MySQL connector's built-in version handling, this fix:

1. **Stores StarRocks version separately**: Uses custom connection attributes (`connection.starrocks_version` and `connection.starrocks_version_string`) instead of overwriting `connection.handle.server_version`
2. **Improves version parsing**: Fixed `_parse_version()` function to correctly handle StarRocks version formats like `"3.4.3-a01aa59"`
3. **Updates version methods**: Modified `is_before_version()` and `current_version()` methods to use the new StarRocks-specific version attributes

## Changes Made

### `connections.py`
- **Fixed `_parse_version()` function**: Now correctly parses StarRocks version strings with build suffixes (e.g., `"3.4.3-a01aa59"`)
- **Updated version detection logic**: Stores version info in `connection.starrocks_version` instead of attempting to set `connection.handle.server_version`
- **Added error handling**: Provides fallback version info when detection fails

### `impl.py`
- **Updated `is_before_version()` method**: Now uses `connection.starrocks_version` instead of `connection.handle.server_version`
- **Updated `current_version()` method**: Now uses `connection.starrocks_version` instead of `connection.handle.server_version`
- **Added safety checks**: Methods now check for the existence of StarRocks version attributes before accessing them

## Compatibility

- ✅ **Backward compatible**: Existing functionality remains unchanged
- ✅ **MySQL connector agnostic**: No longer depends on specific MySQL connector version behavior
- ✅ **StarRocks version support**: Correctly handles all StarRocks version formats (e.g., `3.4.3`, `3.4.3-a01aa59`)

## Testing

The fix has been tested with:
- StarRocks version `3.4.3-a01aa59`
- Various version string formats
- Both automatic version detection and manual version specification via `profiles.yml`

## Before/After

**Before**: 
```
Got an error when obtain StarRocks version exception: 'property 'server_version' of 'CMySQLConnection' object has no setter'
```

**After**:
```
Detected StarRocks version: 3.4.3-a01aa59 -> (3, 4, 3)
```

This fix resolves the connection issue and enables proper StarRocks version detection for feature compatibility checks.