### PR TITLE
feat: accept TABLE as table type

### DIFF
--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -41,7 +41,7 @@
           null as "table_database",
           table_schema,
           table_name,
-          case when table_type = 'BASE TABLE' then 'table'
+          case when table_type = 'BASE TABLE' or table_type = 'TABLE' then 'table'
                when table_type = 'VIEW' then 'view'
                else table_type
           end as table_type,


### PR DESCRIPTION
## Fix: DBT `on_schema_change` not working on StarRocks with append_new_columns option over incremental table materializations


**Problem:**
The DBT [`[on_schema_change](https://docs.getdbt.com/docs/build/incremental-models#what-if-the-columns-of-my-incremental-model-change)`](https://docs.getdbt.com/docs/build/incremental-models#what-if-the-columns-of-my-incremental-model-change) configuration is currently failing because the code only recognizes `BASE TABLE` as a valid table type when detecting schema changes.

<img width="1154" height="80" alt="Screenshot 2025-08-14 at 13 45 37" src="https://github.com/user-attachments/assets/f2635612-7323-41b5-a323-06e3ddfa123b" />

**Root Cause:**
According to the [[StarRocks documentation](https://docs.starrocks.io/docs/sql-reference/information_schema/tables/)](https://docs.starrocks.io/docs/sql-reference/information_schema/tables/), the `information_schema.tables` view can return two different table types:
- `TABLE` 
- `BASE TABLE`

In StarRocks version 3.4.3, only `TABLE` appears to be returned, but our current implementation only checks for `BASE TABLE`.

**Solution:**
This PR updates the materialization logic to accept both `TABLE` and `BASE TABLE` as valid table types when processing schema changes, ensuring compatibility across different StarRocks versions.