### PR TITLE
Fix TestBaseAdapterMethod Test

### DIFF
--- a/dbt/include/starrocks/macros/adapters/columns.sql
+++ b/dbt/include/starrocks/macros/adapters/columns.sql
@@ -31,14 +31,17 @@
     order by ordinal_position
   {% endcall %}
 
-  {% call statement('desc_columns_in_relation', fetch_result=True) %}
-        desc `{{ relation.schema }}`.`{{ relation.identifier }}`
-  {% endcall %}
-
   {% set table = load_result('get_columns_in_relation').table %}
-  {% set desc_table = load_result('desc_columns_in_relation').table %}
-
-  {{ return(starrocks__sql_convert_columns_in_relation(relation, table, desc_table)) }}
+  
+  {% if table.rows %}
+    {% call statement('desc_columns_in_relation', fetch_result=True) %}
+      desc `{{ relation.schema }}`.`{{ relation.identifier }}`
+    {% endcall %}
+    {% set desc_table = load_result('desc_columns_in_relation').table %}
+    {{ return(starrocks__sql_convert_columns_in_relation(relation, table, desc_table)) }}
+  {% else %}
+    {{ return([]) }}
+  {% endif %}
 {% endmacro %}
 
 {% macro starrocks__sql_convert_columns_in_relation(relation, table, desc_table) -%}


### PR DESCRIPTION
The `TestBaseAdapterMethod::test_adapter_methods` test fails on fresh StarRocks clusters because it expects the `models` table to exist. Describing the tables before it is created in the compile step causes this line to fail. By checking whether the table exists first, the macro will either correctly return that there are no columns or the existing columns. 

## Testing
A fresh StarRocks cluster was started locally using the `starrocks/allin1-ubuntu` image. Then running `pytest` passes the offending test case. 