### PR TITLE
fix: Fix get_catalog macro

### DIFF
--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -72,7 +72,7 @@
         columns.column_type,
         columns.column_comment
     from tables
-    join columns using (table_schema, table_name)
+    join columns on tables.table_schema = columns.table_schema and tables.table_name = columns.table_name
     where tables.table_schema not in ('information_schema', '__statistics__')
     and (
     {%- for schema in schemas -%}


### PR DESCRIPTION
# Problem statement

Starrocks version: 4.0.2

Trying to run

```bash
dbt docs generate
```

I'm getting an error:

```text
1064 (HY000): Getting analyzing error. Detail message: Column '`columns`.`table_schema`' cannot be resolved.
```

This MR fixes the issue.