### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Check CI status
         run: |
@@ -27,12 +30,16 @@ jobs:
 
           # Get the latest CI run for this commit
           CI_STATUS=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
-            --jq '.check_runs[] | select(.name == "integration-test") | .conclusion')
+            --jq '[.check_runs[] | select(.name == "integration-test")] | first | .conclusion // empty')
 
           if [ "$CI_STATUS" = "success" ]; then
             echo "CI workflow passed for commit ${{ github.sha }}"
+          elif [ -z "$CI_STATUS" ]; then
+            echo "CI workflow has not run for this commit"
+            echo "Please ensure the 'Integration Tests' workflow passes before releasing."
+            exit 1
           else
-            echo "CI workflow has not passed for this commit (status: ${CI_STATUS:-not found})"
+            echo "CI workflow has not passed for this commit (status: $CI_STATUS)"
             echo "Please ensure the 'Integration Tests' workflow passes before releasing."
             exit 1
           fi
@@ -96,14 +103,13 @@ jobs:
           fi
 
           # Save changelog to file to preserve formatting
-          echo "$CHANGELOG" > /tmp/release_notes.md
+          printf '%s\n' "$CHANGELOG" > /tmp/release_notes.md
           echo "Release notes:"
           cat /tmp/release_notes.md
 
       - name: Build package
         run: |
           source .venv/bin/activate
-          uv pip install build
           python -m build
 
       - name: Dry-run summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip PyPI publish and GitHub release)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python
+        run: uv venv --python 3.11
+
+      - name: Install MySQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client=8.0*
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install -r dev_requirements.txt
+          uv pip install -e .
+
+      - name: Read version from file
+        id: get_version
+        run: |
+          VERSION=$(grep -E "^version = " dbt/adapters/starrocks/__version__.py | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version to release: $VERSION"
+
+      - name: Verify version consistency
+        run: |
+          VERSION_FILE=$(grep -E "^version = " dbt/adapters/starrocks/__version__.py | cut -d'"' -f2)
+          VERSION_SETUP=$(grep -E "^package_version = " setup.py | cut -d'"' -f2)
+          if [ "$VERSION_FILE" != "$VERSION_SETUP" ]; then
+            echo "Error: Version mismatch between __version__.py ($VERSION_FILE) and setup.py ($VERSION_SETUP)"
+            exit 1
+          fi
+          echo "Version consistency verified: $VERSION_FILE"
+
+      - name: Check if tag exists
+        run: |
+          if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Error: Tag v${{ steps.get_version.outputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Run unit tests
+        run: |
+          source .venv/bin/activate
+          uv run pytest tests/unit
+
+      - name: Build package
+        run: |
+          source .venv/bin/activate
+          uv pip install build
+          python -m build
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Version: ${{ steps.get_version.outputs.version }}"
+          echo "Tag: v${{ steps.get_version.outputs.version }}"
+          echo ""
+          echo "Build artifacts created:"
+          ls -lh dist/
+          echo ""
+          echo "Release notes would be:"
+          cat /tmp/release_notes.md
+
+      - name: Publish to PyPI
+        if: ${{ !inputs.dry_run }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if [ -f CHANGELOG.md ]; then
+            # Extract the changelog section for this version
+            CHANGELOG=$(awk "/## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+            if [ -z "$CHANGELOG" ]; then
+              echo "No changelog entry found for version $VERSION"
+              CHANGELOG="Release version $VERSION"
+            fi
+          else
+            echo "CHANGELOG.md not found"
+            CHANGELOG="Release version $VERSION"
+          fi
+          # Save changelog to file to preserve formatting
+          echo "$CHANGELOG" > /tmp/release_notes.md
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: v${{ steps.get_version.outputs.version }}
+          body_path: /tmp/release_notes.md
+          draft: false
+          prerelease: false
+          files: |
+            dist/*.whl
+            dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   release:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,29 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Check CI status
+        run: |
+          echo "Checking if CI workflow passed for this commit..."
+
+          # Get the latest CI run for this commit
+          CI_STATUS=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
+            --jq '.check_runs[] | select(.name == "integration-test") | .conclusion')
+
+          if [ "$CI_STATUS" = "success" ]; then
+            echo "CI workflow passed for commit ${{ github.sha }}"
+          else
+            echo "CI workflow has not passed for this commit (status: ${CI_STATUS:-not found})"
+            echo "Please ensure the 'Integration Tests' workflow passes before releasing."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -26,15 +45,10 @@ jobs:
       - name: Install Python
         run: uv venv --python 3.11
 
-      - name: Install MySQL client
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-client=8.0*
-
       - name: Install dependencies
         run: |
           source .venv/bin/activate
-          uv pip install -r dev_requirements.txt
+          uv pip install build
           uv pip install -e .
 
       - name: Read version from file
@@ -61,10 +75,30 @@ jobs:
             exit 1
           fi
 
-      - name: Run unit tests
+      - name: Extract changelog for this version
+        id: changelog
         run: |
-          source .venv/bin/activate
-          uv run pytest tests/unit
+          VERSION="${{ steps.get_version.outputs.version }}"
+          echo "Extracting changelog for version $VERSION..."
+
+          if [ ! -f CHANGELOG.md ]; then
+            echo "Error: CHANGELOG.md not found"
+            exit 1
+          fi
+
+          # Extract the changelog section for this version
+          CHANGELOG=$(awk "/## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          if [ -z "$CHANGELOG" ]; then
+            echo "Error: No changelog entry found for version $VERSION"
+            echo "Please add a changelog entry in CHANGELOG.md for version $VERSION before releasing."
+            exit 1
+          fi
+
+          # Save changelog to file to preserve formatting
+          echo "$CHANGELOG" > /tmp/release_notes.md
+          echo "Release notes:"
+          cat /tmp/release_notes.md
 
       - name: Build package
         run: |
@@ -89,24 +123,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Extract changelog for this version
-        id: changelog
-        run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-          if [ -f CHANGELOG.md ]; then
-            # Extract the changelog section for this version
-            CHANGELOG=$(awk "/## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
-            if [ -z "$CHANGELOG" ]; then
-              echo "No changelog entry found for version $VERSION"
-              CHANGELOG="Release version $VERSION"
-            fi
-          else
-            echo "CHANGELOG.md not found"
-            CHANGELOG="Release version $VERSION"
-          fi
-          # Save changelog to file to preserve formatting
-          echo "$CHANGELOG" > /tmp/release_notes.md
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.11.0] - 2025-10-16
+
+### Added
+- CI Pipeline (#84)
+- Apache License 2.0 (#85)
+- Support for external materializations (#79)
+
+### Changed
+- Updated dbt support version (#82)
+
+### Fixed
+- Columns description (#83)
+
+## [1.10.1] - 2025-09-11
+
+### Fixed
+- `add_begin_query` method issue in connections.py for StarRocks 3.5.0+ (#74)
+
+## [1.10.0] - 2025-06-04
+
+### Added
+- `auth_plugin` parameter to dbt-starrocks (#69)
+- Support for table as a possible table type option (#77)
+
+### Changed
+- Adjusted SQL hint position for incremental materialization (#67)
+
+## [1.9.0] - 2025-03-20
+
+### Added
+- Support for `microbatch` incremental strategy on dbt-core 1.9.0 (#62)
+- Submittable ETL task (#63)
+- `incremental_strategy` configuration with support for dynamic overwrites (#59)
+
+### Fixed
+- Python 3.9.x compatibility problem (#66)
+
+## [1.7.0] - 2024-10-14
+
+### Added
+- Support for Python 3.12
+- Allow `unique_id` to take a list (#55)
+
+### Fixed
+- Parameter issues when executing the `dbt docs generate` command (#54)
+
+## [1.6.3] - 2024-07-26
+
+### Added
+- Automatic bucketing when no buckets are specified (#50)
+
+### Changed
+- Updated to dbt-core 1.8.4 (#51)
+
+### Fixed
+- Other connection exceptions (#52)
+
+## [1.6.2] - 2024-04-14
+
+### Added
+- Enable C extensions (#46)
+- Support for complex types when adding columns (#43)
+
+### Fixed
+- JSONDecodeError import (#40)
+
+## [1.6.1] - 2024-04-02
+
+### Added
+- Support for different ssl_mode options (#36)
+- Basic unit tests
+
+### Changed
+- Upgraded to dbt-core 1.6.10
+- Updated GitHub repository location
+
+### Fixed
+- Issue with parsing version number when version not defined in profiles.yml
+- Cast from str to int issue
+- MySQL connector errors (Unread result found)
+- Server version detection issue
+- CTE relation type handling
+- Better defaults for testing
+
+## [1.1.1] - 2023-07-20
+
+### Added
+- Table supports multiple data models (#10)
+
+### Fixed
+- StarRocks adapter availability issue (#3)
+- `distributed_by` parameter
+
+### Changed
+- Initial project structure and core functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
-
-### Security
+- `get_catalog` macro (#89)
 
 ## [1.11.0] - 2025-10-16
 
@@ -102,15 +93,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server version detection issue
 - CTE relation type handling
 - Better defaults for testing
-
-## [1.1.1] - 2023-07-20
-
-### Added
-- Table supports multiple data models (#10)
-
-### Fixed
-- StarRocks adapter availability issue (#3)
-- `distributed_by` parameter
-
-### Changed
-- Initial project structure and core functionality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to dbt-starrocks
+
+## Changelog Requirements
+
+**All user-facing changes must be documented in CHANGELOG.md** following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+### How to Update
+
+Add your changes under the `[Unreleased]` section:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+- Your PR here!
+
+### Added
+```
+
+### Categories
+- **Added**: New features
+- **Changed**: Changes to existing functionality
+- **Fixed**: Bug fixes
+- **Removed**: Removed features
+
+### What to Skip
+Internal changes like CI/CD improvements, test updates, or refactoring don't need changelog entries.
+
+### Note
+Releases will fail if no changelog entry exists for the version being released.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,33 @@
+# Release Process
+
+## Steps
+
+### 1. Create Version Bump PR
+
+Update version in both files:
+- [`setup.py`](setup.py#L44): `package_version = "1.12.0"`
+- [`dbt/adapters/starrocks/__version__.py`](dbt/adapters/starrocks/__version__.py#L16): `version = "1.12.0"`
+
+Move `[Unreleased]` items in [`CHANGELOG.md`](CHANGELOG.md) to new version section.
+
+### 2. Merge PR to main
+
+Ensure CI passes before merging.
+
+### 3. Run Release Workflow
+
+Go to **Actions → Release → Run workflow**
+
+**Dry-run (recommended first):**
+- Check "Dry run" 
+- Verify output
+
+**Actual release:**
+- Uncheck "Dry run"
+- Workflow publishes to PyPI and creates GitHub release
+
+## The workflow will fail if:
+- CI hasn't passed
+- Version mismatch between files
+- No changelog entry exists for version
+- Tag already exists


### PR DESCRIPTION
## Description
Resolves #81. 
In this PR, I add a GitHub actions workflow that verifies that CI has passed and then releases to PyPI and on GitHub Releases. This includes a `CHANGELOG.md` file, following the specification described by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Future PRs with user-facing changes should update this changelog, as is documented in `CONTRIBUTING.md`. 

This should make it clear in the future what features/bug fixes are added in any given release. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes an automated release process and supporting documentation.
> 
> - Adds `/.github/workflows/release.yml` with CI gating (checks `integration-test` status), version consistency check between `setup.py` and `dbt/adapters/starrocks/__version__.py`, CHANGELOG extraction for release notes, package build via `uv`/`build`, optional dry-run, and publishing to PyPI and GitHub Releases with artifacts
> - Introduces `CHANGELOG.md` (Keep a Changelog), `CONTRIBUTING.md` (changelog requirements), and `RELEASING.md` (version bump steps and failure conditions)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 065c7c153d5e52d1898263d4115ea4e72d796392. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->