### PR TITLE
[Materialization] Add `on_view_exists` to Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `on_view_exists='replace'` option for view materialization (#95)
+
 ### Changed
 - Remove repication_num=1 by default (#100)
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ models:
   partition_type: 'RANGE'               // RANGE or LIST or Expr Need to be used in combination with partition_by configuration
   properties: {"replication_num":"1", "in_memory": "true"}
   refresh_method: 'async'               // only for materialized view default manual
+  on_view_exists: 'replace'             // only for view: use CREATE OR REPLACE VIEW instead of DROP + CREATE
 
   // For 'materialized=incremental' in version >= 3.4
   incremental_strategy: 'dynamic_overwrite' // Supported values: ['default', 'insert_overwrite', 'dynamic_overwrite']
@@ -118,6 +119,7 @@ models:
 #### Example configuration:
 ```
 {{ config(materialized='view') }}
+{{ config(materialized='view', on_view_exists='replace') }}
 {{ config(materialized='table', engine='OLAP', buckets=32, distributed_by=['id']) }}
 {{ config(materialized='table', indexs=[{ 'columns': 'idx_column' }]) }}
 {{ config(materialized='table', partition_by=['date_trunc("day", first_order)'], partition_type='Expr') }}

--- a/dbt/include/starrocks/macros/materializations/models/view.sql
+++ b/dbt/include/starrocks/macros/materializations/models/view.sql
@@ -16,11 +16,21 @@
 
 {% macro starrocks__create_view_as(relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
+  {%- set refresh_mode = config.get('refresh_mode', none) -%}
 
   {{ sql_header if sql_header is not none }}
-  create view {{ relation }} as {{ sql }};
+  
+  {%- if refresh_mode == 'replace' -%}
+    create or replace view {{ relation }} as {{ sql }};
+  {%- else -%}
+    create view {{ relation }} as {{ sql }};
+  {%- endif -%}
 {%- endmacro %}
 
 {% macro starrocks__drop_view(relation) -%}
-  drop view if exists {{ relation.render() }}
+  {%- set refresh_mode = config.get('refresh_mode', none) -%}
+  {%- if refresh_mode == 'replace' -%}
+  {%- else -%}
+    drop view if exists {{ relation.render() }}
+  {%- endif -%}
 {%- endmacro %}

--- a/dbt/include/starrocks/macros/materializations/models/view.sql
+++ b/dbt/include/starrocks/macros/materializations/models/view.sql
@@ -16,11 +16,11 @@
 
 {% macro starrocks__create_view_as(relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
-  {%- set refresh_mode = config.get('refresh_mode', none) -%}
+  {%- set on_view_exists = config.get('on_view_exists', none) -%}
 
   {{ sql_header if sql_header is not none }}
   
-  {%- if refresh_mode == 'replace' -%}
+  {%- if on_view_exists == 'replace' -%}
     create or replace view {{ relation }} as {{ sql }};
   {%- else -%}
     create view {{ relation }} as {{ sql }};
@@ -28,8 +28,8 @@
 {%- endmacro %}
 
 {% macro starrocks__drop_view(relation) -%}
-  {%- set refresh_mode = config.get('refresh_mode', none) -%}
-  {%- if refresh_mode == 'replace' -%}
+  {%- set on_view_exists = config.get('on_view_exists', none) -%}
+  {%- if on_view_exists == 'replace' -%}
   {%- else -%}
     drop view if exists {{ relation.render() }}
   {%- endif -%}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -197,7 +197,7 @@ class TestViewOnViewExists(BaseSimpleMaterializations):
             "view_without_replace.sql": view_without_replace_sql,
         }
 
-    def test_view_on_view_exists(self, project):
+    def test_base(self, project):
         results = run_dbt(["seed"])
         assert len(results) == 1
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -166,3 +166,55 @@ class TestSnapshotTimestampMyAdapter(BaseSnapshotTimestamp):
 
 class TestBaseAdapterMethod(BaseAdapterMethod):
     pass
+
+
+view_with_replace_sql = """
+{{ 
+    config(
+        materialized = 'view',
+        on_view_exists = 'replace'
+    ) 
+}}
+select * from {{ ref('base') }}
+""".lstrip()
+
+view_without_replace_sql = """
+{{ 
+    config(
+        materialized = 'view'
+    ) 
+}}
+select * from {{ ref('base') }}
+""".lstrip()
+
+
+class TestViewOnViewExists(BaseSimpleMaterializations):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "view_with_replace.sql": view_with_replace_sql,
+            "view_without_replace.sql": view_without_replace_sql,
+        }
+
+    def test_view_on_view_exists(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        results = run_dbt(["run"])
+        assert len(results) == 2
+        check_result_nodes_by_name(results, ["view_with_replace", "view_without_replace"])
+
+        expected = {
+            "base": "table",
+            "view_with_replace": "view",
+            "view_without_replace": "view",
+        }
+        check_relation_types(project.adapter, expected)
+
+        check_relations_equal(project.adapter, ["base", "view_with_replace", "view_without_replace"])
+
+        # re-run to verify views can be updated
+        results = run_dbt(["run"])
+        assert len(results) == 2
+        check_relations_equal(project.adapter, ["base", "view_with_replace", "view_without_replace"])


### PR DESCRIPTION
## Add `on_view_exists='replace'` option for view materialization

### What
Adds an opt-in `on_view_exists='replace'` configuration option for view materialization that uses `CREATE OR REPLACE VIEW` instead of the default `DROP VIEW` + `CREATE VIEW` cycle.

Solves partially https://github.com/StarRocks/dbt-starrocks/issues/49

>Same happens with regular views. They do drop&create, causing any dependent mat. view end up in broken and inactive state

Ideally this would be default behavior, we've been running this in production for over a month without any issues.

### Why
The default view refresh behavior drops and recreates views, causing brief downtime that triggers errors in monitoring systems (e.g., Datadog) during view refreshes. Using `CREATE OR REPLACE VIEW` provides atomic view updates without downtime.

### Changes
- When `on_view_exists='replace'` is set, views are updated using `CREATE OR REPLACE VIEW`
- The `drop_view` macro skips dropping views when `on_view_exists='replace'` is configured
- Default behavior remains unchanged (backward compatible, no regression)
- Opt-in feature: existing models continue to use drop+create unless explicitly configured

### Usage

```sql
{{ config(materialized='view', on_view_exists='replace') }}
select * from ...
```