### PR TITLE
fix: skip view backup during rename to prevent stale definition errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `get_catalog` macro (#89)
--  Multiple indexes issue (#97)
+- Multiple indexes issue (#97)
+- View rename to `__dbt_backup` fails during `--full-refresh` when upstream view columns changed
 
 ## [1.11.0] - 2025-10-16
 

--- a/dbt/include/starrocks/macros/adapters/relation.sql
+++ b/dbt/include/starrocks/macros/adapters/relation.sql
@@ -31,12 +31,16 @@
     {%- elif from_relation.is_table and to_relation.is_table %}
        alter table {{ from_relation }} rename {{ to_relation.table }}
     {% elif from_relation.is_view and to_relation.is_view %}
-      {% set results = run_query("select VIEW_DEFINITION as sql from information_schema.views where TABLE_SCHEMA='"
-           + from_relation.schema + "' and TABLE_NAME='" + from_relation.table + "'") %}
-      create view {{ to_relation }} as {{ results[0]['sql'] }}
-      {% call statement('drop_view') %}
+      {% if to_relation.table.endswith('__dbt_backup') %}
         drop view if exists {{ from_relation }}
-      {% endcall %}
+      {% else %}
+        {% set results = run_query("select VIEW_DEFINITION as sql from information_schema.views where TABLE_SCHEMA='"
+             + from_relation.schema + "' and TABLE_NAME='" + from_relation.table + "'") %}
+        create view {{ to_relation }} as {{ results[0]['sql'] }}
+        {% call statement('drop_view') %}
+          drop view if exists {{ from_relation }}
+        {% endcall %}
+      {% endif %}
     {%- else -%}
       {%- set msg -%}
           unsupported rename from {{ from_relation.type }} to {{ to_relation.type }}

--- a/tests/functional/adapter/test_view_rename.py
+++ b/tests/functional/adapter/test_view_rename.py
@@ -1,0 +1,39 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+
+simple_view_sql = """
+{{ config(materialized='view') }}
+select 1 as id, 'hello' as name
+"""
+
+dependent_view_sql = """
+{{ config(materialized='view') }}
+select id, name from {{ ref('base_view') }}
+"""
+
+
+class TestViewFullRefreshSkipsBackup:
+    """Test that full-refresh on views works without stale definition errors.
+
+    When renaming a view to __dbt_backup, the adapter should simply drop
+    the original view instead of trying to recreate it from information_schema,
+    which can fail when upstream views have already been rebuilt.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "base_view.sql": simple_view_sql,
+            "dependent_view.sql": dependent_view_sql,
+        }
+
+    def test_full_refresh_views(self, project):
+        # Initial run creates both views
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Full refresh triggers rename to __dbt_backup then recreate.
+        # This must succeed even though the backup rename skips recreation.
+        results = run_dbt(["run", "--full-refresh"])
+        assert len(results) == 2


### PR DESCRIPTION
Fixes #104

## Problem

During `dbt run --full-refresh`, renaming a view to `__dbt_backup` fails with `Column cannot be resolved` when upstream views have already been rebuilt with different columns in the same run.

StarRocks has no `ALTER VIEW ... RENAME` — the adapter must read `VIEW_DEFINITION` from `information_schema.views` and recreate the view. When the stored definition references columns that no longer exist in already-updated upstream views, the `CREATE VIEW` fails.

## Fix

When the rename target is a `__dbt_backup` view, simply drop the original instead of recreating it. Views hold no data, so a backup serves no purpose — and dbt calls `DROP IF EXISTS` on the backup later anyway.

The existing logic for `__dbt_tmp → final` renames (read fresh definition from `information_schema`) remains unchanged.

## Steps to Reproduce

See #104 for detailed reproduction steps.