### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         starrocks-version: ['3.5.14', '4.0-latest', '4.1.0-rc01']
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Install Python
-        run: uv venv --python 3.11
+        run: uv venv --python 3.13
 
       - name: Install dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@
 import os
 import sys
 
-if sys.version_info < (3, 9) or sys.version_info >= (3, 13):
+if sys.version_info < (3, 9) or sys.version_info >= (3, 14):
     print("Error: dbt-starrocks does not support this version of Python.")
-    print("Please install Python 3.9 or higher but less than 3.13.")
+    print("Please install Python 3.9 or higher but less than 3.14.")
     sys.exit(1)
 
 from setuptools import find_namespace_packages, setup
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.9,<3.13",
+    python_requires=">=3.9,<3.14",
 )


### PR DESCRIPTION
## Summary
- Extend `python_requires` from `<3.13` to `<3.14` and update the version guard in `setup.py`
- Add PyPI classifier for Python 3.13
- Bump CI and release workflows from Python 3.11 to 3.13

## Test plan
- [ ] CI integration tests pass on Python 3.13
- [ ] `pip install` works on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)