### PR TITLE
Fix dbt seed failing on CSV columns with decimal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple indexes issue (#97)
 - View rename to `__dbt_backup` fails during `--full-refresh` when upstream view columns changed
 - Implement StarRocks DBAPI type-code conversion for dbt query schema inference
+- `dbt seed` fails on CSV columns with decimal values because the inherited `convert_number_type` returns the Postgres-flavoured `float8` type
 
 ## [1.11.0] - 2025-10-16
 

--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -255,6 +255,15 @@ class StarRocksAdapter(SQLAdapter):
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "string"
 
+    @classmethod
+    def convert_number_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        # The base SQLAdapter returns "float8" for decimal columns, which is a
+        # Postgres alias StarRocks doesn't accept (its parser treats the "8" as
+        # an expected precision and complains about the missing "("). Use the
+        # standard StarRocks type instead.
+        decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
+        return "double" if decimals else "bigint"
+
     def quote(self, identifier):
         return "`{}`".format(identifier)
 

--- a/tests/functional/adapter/test_seed_decimal.py
+++ b/tests/functional/adapter/test_seed_decimal.py
@@ -1,0 +1,40 @@
+import pytest
+
+from dbt.tests.util import relation_from_name, run_dbt
+
+# A seed with a decimal column reproduces the original bug: the base adapter
+# emitted "float8" for `rate`, which StarRocks fails to parse.
+decimal_seed_csv = """
+id,rate
+a,0.06
+b,0.04
+c,0.0625
+""".lstrip()
+
+
+class TestSeedWithDecimalColumn:
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"decimal_seed.csv": decimal_seed_csv}
+
+    def test_seed_with_decimal(self, project):
+        # seed command must succeed (used to fail with a syntax error on float8)
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        relation = relation_from_name(project.adapter, "decimal_seed")
+
+        # all rows landed
+        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+        assert result[0] == 3
+
+        # the decimal column was created as a StarRocks "double", not "float8"
+        col_type = project.run_sql(
+            f"select data_type from information_schema.columns "
+            f"where table_schema = '{relation.schema}' "
+            f"and table_name = '{relation.identifier}' "
+            f"and column_name = 'rate'",
+            fetch="one",
+        )
+        assert col_type[0].lower() == "double"

--- a/tests/unit/test_convert_number_type.py
+++ b/tests/unit/test_convert_number_type.py
@@ -1,0 +1,28 @@
+import agate
+
+from dbt.adapters.starrocks.impl import StarRocksAdapter
+
+
+def _table(values):
+    """Build a single-column agate table inferred from *values*."""
+    return agate.Table.from_object([{"col": v} for v in values])
+
+
+class TestConvertNumberType:
+    """Regression tests for `convert_number_type`.
+
+    The base SQLAdapter implementation returns ``"float8"`` for any numeric
+    column with decimals, which is a Postgres alias StarRocks doesn't parse.
+    """
+
+    def test_decimal_column_maps_to_double(self):
+        table = _table(["0.06", "0.04", "0.0625"])
+        assert StarRocksAdapter.convert_number_type(table, 0) == "double"
+
+    def test_integer_column_maps_to_bigint(self):
+        table = _table(["1", "2", "3"])
+        assert StarRocksAdapter.convert_number_type(table, 0) == "bigint"
+
+    def test_mixed_int_and_decimal_treated_as_decimal(self):
+        table = _table(["1", "2.5", "3"])
+        assert StarRocksAdapter.convert_number_type(table, 0) == "double"


### PR DESCRIPTION
## Problem

`dbt seed` fails on any CSV containing a column with decimal values:

```
1064 (HY000): Getting syntax error at line 8, column 4.
Detail message: Unexpected input ')', the most similar input is {'('}.
```

The emitted DDL is:

```sql
create table `raw`.`raw_stores` (
    `id` string,
    `name` string,
    `opened_at` datetime,
    `tax_rate` float8     -- ← StarRocks doesn't recognise float8
) ENGINE = OLAP
PROPERTIES ("replication_num" = "1")
```

## Root cause

`StarRocksAdapter` overrides `convert_datetime_type` and `convert_text_type` but inherits `convert_number_type` from the base SQLAdapter, which returns the literal string `"float8"` (a Postgres alias for `double precision`) for any numeric column with decimals. StarRocks doesn't recognise `float8` — its parser treats the `8` as an expected precision modifier and raises a misleading "Unexpected input `)`, expected `(`" on the closing paren of the column list.

Integer-only and text-only CSVs are unaffected (they go through `convert_integer_type` / `convert_text_type`, both of which work).

## Fix

Override `convert_number_type` in `StarRocksAdapter` to return `"double"` for decimal columns and `"bigint"` for integers — both standard StarRocks types.

## Reproduction

```csv
# seeds/rate.csv
id,rate
a,0.06
b,0.04
```
```
$ dbt seed --select rate
Database Error in seed rate (seeds/rate.csv)
  1064 (HY000): Getting syntax error at line 8, column 4. ...
```

## Tests

Added unit tests in `tests/unit/test_convert_number_type.py` covering decimal, integer, and mixed-precision columns. Existing unit tests still pass (`pytest tests/unit/` → 8 passed).

## Changelog

Entry added under `[Unreleased] → Fixed`.