### PR TITLE
Support data type code conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_catalog` macro (#89)
 - Multiple indexes issue (#97)
 - View rename to `__dbt_backup` fails during `--full-refresh` when upstream view columns changed
+- Implement StarRocks DBAPI type-code conversion for dbt query schema inference
 
 ## [1.11.0] - 2025-10-16
 

--- a/dbt/adapters/starrocks/connections.py
+++ b/dbt/adapters/starrocks/connections.py
@@ -16,6 +16,7 @@
 from contextlib import contextmanager
 
 import mysql.connector
+from mysql.connector.constants import FieldType
 
 import dbt.exceptions
 import dbt_common.exceptions
@@ -28,7 +29,7 @@ from dbt.adapters.contracts.connection import (
 )
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.adapters.events.logging import AdapterLogger
-from typing import Optional
+from typing import Optional, Union
 
 logger = AdapterLogger("starrocks")
 
@@ -108,6 +109,44 @@ def _parse_version(result):
 
 class StarRocksConnectionManager(SQLConnectionManager):
     TYPE = 'starrocks'
+    TYPE_CODE_TO_NAME = {
+        FieldType.DECIMAL: "decimal",
+        FieldType.NEWDECIMAL: "decimal",
+        FieldType.TINY: "tinyint",
+        FieldType.SHORT: "smallint",
+        FieldType.LONG: "int",
+        FieldType.INT24: "int",
+        FieldType.LONGLONG: "bigint",
+        FieldType.FLOAT: "float",
+        FieldType.DOUBLE: "double",
+        FieldType.DATE: "date",
+        FieldType.DATETIME: "datetime",
+        FieldType.TIMESTAMP: "datetime",
+        FieldType.TIME: "varchar",
+        FieldType.YEAR: "smallint",
+        FieldType.VARCHAR: "varchar",
+        FieldType.VAR_STRING: "varchar",
+        FieldType.STRING: "varchar",
+        FieldType.BLOB: "varbinary",
+        FieldType.BIT: "tinyint",
+        FieldType.JSON: "json",
+    }
+
+    @classmethod
+    def data_type_code_to_name(cls, type_code: Union[int, str]) -> str:
+        if isinstance(type_code, str):
+            return type_code.lower()
+
+        data_type = cls.TYPE_CODE_TO_NAME.get(type_code)
+        if data_type:
+            return data_type
+
+        mysql_type_name = FieldType.get_info(type_code)
+        if mysql_type_name:
+            return mysql_type_name.lower()
+
+        logger.warning("Unknown StarRocks data type code: %s", type_code)
+        return str(type_code)
 
     @classmethod
     def open(cls, connection):

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -1,0 +1,29 @@
+from mysql.connector.constants import FieldType
+
+from dbt.adapters.starrocks.connections import StarRocksConnectionManager
+
+
+def test_data_type_code_to_name_maps_mysql_connector_type_codes():
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.DECIMAL) == "decimal"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.DATE) == "date"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.DATETIME) == "datetime"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.TIMESTAMP) == "datetime"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.LONGLONG) == "bigint"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.NEWDECIMAL) == "decimal"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.TIME) == "varchar"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.YEAR) == "smallint"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.VAR_STRING) == "varchar"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.BLOB) == "varbinary"
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.BIT) == "tinyint"
+
+
+def test_data_type_code_to_name_normalizes_string_type_codes():
+    assert StarRocksConnectionManager.data_type_code_to_name("VARCHAR") == "varchar"
+
+
+def test_data_type_code_to_name_falls_back_to_mysql_connector_name():
+    assert StarRocksConnectionManager.data_type_code_to_name(FieldType.GEOMETRY) == "geometry"
+
+
+def test_data_type_code_to_name_logs_unknown_numeric_code():
+    assert StarRocksConnectionManager.data_type_code_to_name(99999) == "99999"


### PR DESCRIPTION
## Summary
- implement `StarRocksConnectionManager.data_type_code_to_name`
- map mysql-connector-python `FieldType` codes to StarRocks/dbt type names
- add unit coverage for common schema-inference type codes and fallback behavior

## Why
`dbt-core` can call `adapter.get_column_schema_from_query`, which executes a zero-row wrapper query and then converts `cursor.description` type codes through `connection.data_type_code_to_name`. Without this method, StarRocks models fail before materialization with:

```text
ERROR: `data_type_code_to_name` is not implemented for this adapter!
```

This affects materializations/macros that infer a query schema directly instead of creating a relation first and introspecting it.

## Test
- `.venv/bin/python -m pytest tests/unit/test_connections.py tests/unit/test_relation_rendering.py tests/unit/test_submit_task.py -q`