### PR TITLE
Enabling relation and column comment creation when persist_docs is set

### DIFF
--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -99,39 +99,36 @@
 {%- endmacro %}
 
 {% macro starrocks__alter_relation_comment(relation, relation_comment) %}
-  {#
-    StarRocks uses ALTER TABLE ... SET COMMENT ... syntax to update 
-    an existing table or view's description.
-  #}
-  {% set comment_escaped = dbt.string_literal(relation_comment) %}
-  
-  ALTER TABLE {{ relation.include(database=False) }} SET COMMENT = {{ comment_escaped }};
+  {% if relation.type == 'table' %}
+    {% call statement('alter_relation_comment') %}
+      ALTER TABLE {{ relation.include(database=False) }} COMMENT = {{ dbt.string_literal(relation_comment) }};
+    {% endcall %}
+  {% endif %}
 {% endmacro %}
 
+
 {% macro starrocks__alter_column_comment(relation, column_name, column_comment) %}
-  {# 
-    StarRocks uses MODIFY COLUMN to alter a column's metadata/comment.
-    Note: In some versions of StarRocks, MODIFY COLUMN requires the data type. 
-    To bypass needing the exact data type, we use ALTER TABLE ... ALTER COLUMN.
-  #}
-  {% set comment_escaped = dbt.string_literal(column_comment) %}
-  
-  ALTER TABLE {{ relation.include(database=False) }} ALTER COLUMN {{ adapter.quote(column_name) }} COMMENT {{ comment_escaped }};
+  {% if relation.type == 'table' %}
+    {% call statement('alter_column_comment') %}
+      ALTER TABLE {{ relation.include(database=False) }} MODIFY COLUMN {{ adapter.quote(column_name) }} COMMENT {{ dbt.string_literal(column_comment) }};
+    {% endcall %}
+  {% endif %}
 {% endmacro %}
 
 
 {% macro starrocks__persist_from_relations(relation, model) %}
-  {#
-    This macro hooks into dbt's post-materialization phase to loop through 
-    configured columns and fire off the column comment updates.
-  #}
-  {% if config.get('persist_docs', {}).get('columns', false) and model.columns %}
-    {% for col in model.columns.values() %}
-      {% if col.description %}
-        {% call statement('alter_column_comment') %}
+  {% if model.config.materialized == 'table' or model.config.materialized == 'incremental' %}
+
+    {% if config.get('persist_docs', {}).get('relation', false) and model.description %}
+      {{ starrocks__alter_relation_comment(relation, model.description) }}
+    {% endif %}
+
+    {% if config.get('persist_docs', {}).get('columns', false) and model.columns %}
+      {% for col in model.columns.values() %}
+        {% if col.description %}
           {{ starrocks__alter_column_comment(relation, col.name, col.description) }}
-        {% endcall %}
-      {% endif %}
-    {% endfor %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -107,3 +107,31 @@
   
   ALTER TABLE {{ relation.include(database=False) }} SET COMMENT = {{ comment_escaped }};
 {% endmacro %}
+
+{% macro starrocks__alter_column_comment(relation, column_name, column_comment) %}
+  {# 
+    StarRocks uses MODIFY COLUMN to alter a column's metadata/comment.
+    Note: In some versions of StarRocks, MODIFY COLUMN requires the data type. 
+    To bypass needing the exact data type, we use ALTER TABLE ... ALTER COLUMN.
+  #}
+  {% set comment_escaped = dbt.string_literal(column_comment) %}
+  
+  ALTER TABLE {{ relation.include(database=False) }} ALTER COLUMN {{ adapter.quote(column_name) }} COMMENT {{ comment_escaped }};
+{% endmacro %}
+
+
+{% macro starrocks__persist_from_relations(relation, model) %}
+  {#
+    This macro hooks into dbt's post-materialization phase to loop through 
+    configured columns and fire off the column comment updates.
+  #}
+  {% if config.get('persist_docs', {}).get('columns', false) and model.columns %}
+    {% for col in model.columns.values() %}
+      {% if col.description %}
+        {% call statement('alter_column_comment') %}
+          {{ starrocks__alter_column_comment(relation, col.name, col.description) }}
+        {% endcall %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -97,3 +97,13 @@
     {%- endcall %}
     {{ return(load_result('list_schemas').table) }}
 {%- endmacro %}
+
+{% macro starrocks__alter_relation_comment(relation, relation_comment) %}
+  {#
+    StarRocks uses ALTER TABLE ... SET COMMENT ... syntax to update 
+    an existing table or view's description.
+  #}
+  {% set comment_escaped = dbt.string_literal(relation_comment) %}
+  
+  ALTER TABLE {{ relation.include(database=False) }} SET COMMENT = {{ comment_escaped }};
+{% endmacro %}

--- a/dbt/include/starrocks/macros/materializations/models/table.sql
+++ b/dbt/include/starrocks/macros/materializations/models/table.sql
@@ -20,6 +20,12 @@
   {%- set indexs = config.get('indexs') -%}
   {%- set properties = config.get('properties') -%}
 
+  {#- Check if persist_docs is enabled for the relation and retrieve the description -#}
+  {%- set relation_comment = none -%}
+  {%- if config.get('persist_docs', {}).get('relation', false) -%}
+    {%- set relation_comment = model.description -%}
+  {%- endif -%}
+
   {{ sql_header if sql_header is not none }}
 
   create table {{ relation.include(database=False) }}
@@ -41,6 +47,10 @@
     {%- endset %}
     {{ exceptions.raise_compiler_error(msg) }}
   {%- endif -%}
+  
+  {%- if relation_comment is not none %}
+  COMMENT {{ dbt.string_literal(relation_comment) }}
+  {%- endif %}
 
   as {{ sql }}
 

--- a/dbt/include/starrocks/macros/materializations/models/view.sql
+++ b/dbt/include/starrocks/macros/materializations/models/view.sql
@@ -20,11 +20,22 @@
 
   {{ sql_header if sql_header is not none }}
   
-  {%- if on_view_exists == 'replace' -%}
-    create or replace view {{ relation }} as {{ sql }};
-  {%- else -%}
-    create view {{ relation }} as {{ sql }};
-  {%- endif -%}
+  create or replace view {{ relation }}
+
+  {%- if config.get('persist_docs', {}).get('columns', false) and model.columns -%}
+    (
+    {%- for col in model.columns.values() %}
+      {{ adapter.quote(col.name) }} {% if col.description -%} COMMENT {{ dbt.string_literal(col.description) }} {%- endif -%}
+      {{ "," if not loop.last }}
+    {%- endfor %}
+    )
+  {%- endif %}
+
+  {%- if config.get('persist_docs', {}).get('relation', false) and model.description -%}
+    COMMENT {{ dbt.string_literal(model.description) }}
+  {%- endif %}
+
+  as {{ sql }};
 {%- endmacro %}
 
 {% macro starrocks__drop_view(relation) -%}
@@ -34,3 +45,4 @@
     drop view if exists {{ relation.render() }}
   {%- endif -%}
 {%- endmacro %}
+

--- a/dbt/include/starrocks/macros/materializations/table.sql
+++ b/dbt/include/starrocks/macros/materializations/table.sql
@@ -86,5 +86,8 @@
   
   {{ run_hooks(post_hooks) }}
   
+  {# Apply column comments if configured #}
+  {% do starrocks__persist_from_relations(target_relation, model) %}
+
   {{ return({'relations': [target_relation]}) }}
 {% endmaterialization %}

--- a/dbt/include/starrocks/macros/materializations/view.sql
+++ b/dbt/include/starrocks/macros/materializations/view.sql
@@ -1,0 +1,41 @@
+{% materialization view, adapter='starrocks' %}
+
+  {%- set identifier = model['alias'] -%}
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database, type='view') -%}
+
+  {#- Look up persist_docs configuration flags -#}
+  {%- set persist_relation = config.get('persist_docs', {}).get('relation', false) -%}
+  {%- set persist_columns = config.get('persist_docs', {}).get('columns', false) -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- Drop the old view if it exists, exactly how the adapter natively does it
+  {% if old_relation is not none %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
+
+  -- Create the fresh view with comments baked straight into the DDL
+  {% call statement('main') -%}
+    CREATE VIEW {{ target_relation.include(database=False) }}
+    
+    {%- if persist_columns and model.columns | length > 0 -%}
+      (
+      {%- for col in model.columns.values() %}
+        {{ adapter.quote(col.name) }}{% if col.description %} COMMENT {{ dbt.string_literal(col.description) }}{% endif %}{{ "," if not loop.last }}
+      {%- endfor %}
+      )
+    {%- endif %}
+
+    {%- if persist_relation and model.description -%}
+      COMMENT {{ dbt.string_literal(model.description) }}
+    {%- endif %}
+    
+    AS {{ sql }};
+  {%- endcall %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}


### PR DESCRIPTION
This pull request enables persisting comments when persist_docs is set and model schema contains description.
https://docs.getdbt.com/reference/resource-configs/persist_docs?version=1.11&name=Core