### PR TITLE
Support Incremental Materialization in External Catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Relations in external catalogs are now discoverable, so `incremental` and `table` models
+  targeting an Iceberg/Hive catalog no longer fail on every run after the first with
+  `Table '<name>' already exists`. `starrocks__list_relations_without_caching` and
+  `starrocks__get_columns_in_relation` qualify `information_schema` with the catalog and
+  report it back as the relation's `database`, and `get_relation` keeps that component
+  instead of dropping it.
+- `incremental` models in an external catalog look their target up by catalog rather than
+  through `this`, which always addresses `default_catalog`.
+- `--full-refresh` on an external-catalog `incremental` model drops and recreates the table
+  instead of using `ALTER TABLE ... SWAP WITH`, which external catalogs do not support.
+
 ## [1.12.1] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,6 +162,29 @@ Finally, you might use below marco quote
 {{ source('external_example', 'hive_table_name') }}
 ```
 
+## Write To Catalog
+Set `catalog` and `database` in a model's config to build it inside an external catalog.
+Both are required together; `catalog` defaults to the profile's `catalog`.
+```
+{{ config(materialized='table', catalog='iceberg_catalog', database='iceberg_db') }}
+{{ config(materialized='incremental', incremental_strategy='dynamic_overwrite',
+          catalog='iceberg_catalog', database='iceberg_db',
+          partition_by=['day(`modified_at`)']) }}
+```
+The table name comes from the model's file name (or its `alias`), not from `database`.
+
+Only `partition_by`, `partition_type` (defaulting to `Expr`), `partition_by_init` and
+`properties` are applied to external tables. `table_type`, `keys`, `distributed_by`,
+`buckets` and `order_by` describe OLAP tables and are ignored here — Iceberg rejects key
+clauses outright.
+
+Because there are no keys, `unique_key` cannot deduplicate an external-catalog incremental
+model: `INSERT INTO` appends. Replace partitions instead, with `insert_overwrite` or
+`dynamic_overwrite`. On Iceberg both replace only the partitions the query produced and
+leave the others in place, so they behave alike there; the difference between them applies
+to OLAP tables. Row-level `unique_key` semantics would need `DELETE` on Iceberg, which
+StarRocks only writes position delete files for from 4.1 onwards.
+
 ## Dynamic Overwrite (StarRocks >= 3.4)
 Add a new `incremental_strategy` property that supports the following values:
 - `default` (or omitted): Standard inserts without `overwrite`.

--- a/dbt/adapters/starrocks/impl.py
+++ b/dbt/adapters/starrocks/impl.py
@@ -43,6 +43,21 @@ logger = AdapterLogger("starrocks")
 SQLQueryResult: TypeAlias = Tuple[AdapterResponse, "agate.Table"]
 
 
+DEFAULT_CATALOG = "default_catalog"
+
+
+def _external_catalog(database: Optional[str]) -> Optional[str]:
+    """Return `database` when it names an external catalog, else None.
+
+    Relations in the internal catalog carry `database = None` (see
+    `starrocks__generate_database_name`), so a value here means the relation
+    lives in an external catalog and must stay addressed by it.
+    """
+    if database is not None and database != DEFAULT_CATALOG:
+        return database
+    return None
+
+
 SUBMIT_TASK_TEMPLATE = "submit /*+set_var(query_timeout={timeout})*/ task {task_id} as {sql}"
 POLL_TASK_TEMPLATE = "select * from information_schema.task_runs where task_name = '{task_id}'"
 
@@ -293,7 +308,13 @@ class StarRocksAdapter(SQLAdapter):
         return exists
 
     def get_relation(self, database: Optional[str], schema: str, identifier: str):
-        if not self.Relation.get_default_include_policy().database:
+        # The include policy drops the database component because internal-catalog
+        # relations are addressed as `schema`.`identifier`. An external catalog is
+        # part of the relation's identity, so it has to survive the lookup.
+        if (
+            _external_catalog(database) is None
+            and not self.Relation.get_default_include_policy().database
+        ):
             database = None
 
         return super().get_relation(database, schema, identifier)
@@ -313,7 +334,7 @@ class StarRocksAdapter(SQLAdapter):
                 )
             _database, name, schema, type_info = row
             relation = self.Relation.create(
-                database=None,
+                database=_external_catalog(_database),
                 schema=schema,
                 identifier=name,
                 type=self.Relation.get_relation_type(type_info),

--- a/dbt/include/starrocks/macros/adapters/columns.sql
+++ b/dbt/include/starrocks/macros/adapters/columns.sql
@@ -15,6 +15,10 @@
  */
 
 {% macro starrocks__get_columns_in_relation(relation) -%}
+  {#-- An unqualified `information_schema` resolves in the session's current catalog, so a
+       relation in an external catalog needs it named explicitly or no columns come back. --#}
+  {%- set catalog = starrocks__external_catalog(relation.database) -%}
+  {%- set information_schema = ('`' ~ catalog ~ '`.information_schema') if catalog is not none else 'INFORMATION_SCHEMA' -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
     select
         column_name,
@@ -23,7 +27,7 @@
         numeric_precision,
         numeric_scale
 
-    from INFORMATION_SCHEMA.columns
+    from {{ information_schema }}.columns
     where table_name = '{{ relation.identifier }}'
       {% if relation.schema %}
       and table_schema = '{{ relation.schema }}'
@@ -35,7 +39,7 @@
   
   {% if table.rows %}
     {% call statement('desc_columns_in_relation', fetch_result=True) %}
-      desc `{{ relation.schema }}`.`{{ relation.identifier }}`
+      desc {{ relation }}
     {% endcall %}
     {% set desc_table = load_result('desc_columns_in_relation').table %}
     {{ return(starrocks__sql_convert_columns_in_relation(relation, table, desc_table)) }}

--- a/dbt/include/starrocks/macros/adapters/metadata.sql
+++ b/dbt/include/starrocks/macros/adapters/metadata.sql
@@ -15,7 +15,22 @@
  */
 
 {% macro starrocks__list_relations_without_caching(schema_relation) -%}
+  {#-- An unqualified `information_schema` resolves in the session's current catalog, so an
+       external catalog has to be named explicitly or its relations are invisible here. The
+       catalog is carried back out as "database" so the relation cache can match on it. --#}
+  {%- set catalog = starrocks__external_catalog(schema_relation.database) -%}
   {% call statement('list_relations_without_caching', fetch_result=True) %}
+    {%- if catalog is not none %}
+    select
+      '{{ catalog }}' as "database",
+      tbl.table_name as name,
+      tbl.table_schema as "schema",
+      case when tbl.table_type = 'BASE TABLE' or tbl.table_type = 'TABLE' then 'table'
+           when tbl.table_type = 'VIEW' then 'view'
+           else 'unknown' end as table_type
+    from `{{ catalog }}`.information_schema.tables tbl
+    where tbl.table_schema = '{{ schema_relation.schema }}'
+    {%- else %}
     select
       null as "database",
       tbl.table_name as name,
@@ -30,6 +45,7 @@
     on tbl.TABLE_SCHEMA = mv.TABLE_SCHEMA
     and tbl.TABLE_NAME = mv.TABLE_NAME
     where tbl.table_schema = '{{ schema_relation.schema }}'
+    {%- endif %}
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {%- endmacro %}

--- a/dbt/include/starrocks/macros/materializations/models/incremental.sql
+++ b/dbt/include/starrocks/macros/materializations/models/incremental.sql
@@ -92,9 +92,7 @@
       ) -%}
     {%- endif -%}
 
-    {#-- `this` always addresses the internal catalog, so an external target has to be
-         looked up by the relation built above or it never appears to exist. --#}
-    {%- set existing_relation = load_relation(target_relation) if is_external else load_relation(this) -%}
+    {%- set existing_relation = load_relation(target_relation) -%}
     {%- set incremental_strategy = starrocks__validate_get_incremental_strategy(config) -%}
 
     {{ drop_relation_if_exists(tmp_relation) }}

--- a/dbt/include/starrocks/macros/materializations/models/incremental.sql
+++ b/dbt/include/starrocks/macros/materializations/models/incremental.sql
@@ -92,7 +92,9 @@
       ) -%}
     {%- endif -%}
 
-    {%- set existing_relation = load_relation(this) -%}
+    {#-- `this` always addresses the internal catalog, so an external target has to be
+         looked up by the relation built above or it never appears to exist. --#}
+    {%- set existing_relation = load_relation(target_relation) if is_external else load_relation(this) -%}
     {%- set incremental_strategy = starrocks__validate_get_incremental_strategy(config) -%}
 
     {{ drop_relation_if_exists(tmp_relation) }}
@@ -109,6 +111,14 @@
     {%- elif existing_relation.is_view -%}
         {#-- Can't overwrite a view with a table, drop it before creating table --#}
         {{ log("Dropping relation " ~ target_relation ~ " because it is a view and this model is a table.") }}
+        {%- do adapter.drop_relation(existing_relation) -%}
+        {%- call statement('main') -%}
+            {{ starrocks__create_table_as(False, target_relation, compiled_code, is_external) }}
+        {%- endcall -%}
+
+    {%- elif full_refresh_mode and is_external -%}
+        {#-- External catalogs have no ALTER TABLE ... SWAP WITH, so the backup-and-exchange
+             route below is unavailable: drop and recreate in place instead. --#}
         {%- do adapter.drop_relation(existing_relation) -%}
         {%- call statement('main') -%}
             {{ starrocks__create_table_as(False, target_relation, compiled_code, is_external) }}

--- a/dbt/include/starrocks/macros/utils/catalog.sql
+++ b/dbt/include/starrocks/macros/utils/catalog.sql
@@ -27,3 +27,14 @@
 {% macro starrocks__is_internal_catalog() -%}
   {{ return(starrocks__catalog_for() == 'default_catalog') }}
 {%- endmacro %}
+
+{# Normalize a relation's `database` component to an external catalog name, or
+   none when it addresses the internal catalog. Relations in `default_catalog`
+   carry `database = none` (see `starrocks__generate_database_name`), so a name
+   here means the relation lives outside it and must be addressed explicitly. #}
+{% macro starrocks__external_catalog(database) -%}
+  {%- if database is not none and database != 'default_catalog' -%}
+    {{ return(database) }}
+  {%- endif -%}
+  {{ return(none) }}
+{%- endmacro %}

--- a/tests/functional/adapter/test_external.py
+++ b/tests/functional/adapter/test_external.py
@@ -79,3 +79,120 @@ class TestExternalCatalogTable:
             "external_table": "table",
         }
         check_relation_types(project.adapter, expected)
+
+
+seed_partition_1_csv = """
+id,partition_key
+1,1
+2,1
+3,1
+4,1
+5,1
+""".lstrip()
+
+seed_partition_1_replaced_plus_2_csv = """
+id,partition_key
+6,1
+7,1
+8,1
+9,1
+10,1
+11,2
+12,2
+13,2
+14,2
+15,2
+""".lstrip()
+
+external_catalog_incremental_sql = """
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'dynamic_overwrite',
+        catalog = 'iceberg_catalog',
+        database = 'dbt_test_db',
+        partition_by = ['partition_key'],
+    )
+}}
+select id, partition_key from {{ ref(var('seed_name')) }}
+""".lstrip()
+
+
+class TestExternalCatalogIncremental:
+    """Test incremental materialization in an external catalog.
+
+    A second run has to find the table it created on the first one. Relations in
+    an external catalog were invisible to the relation cache, so every run after
+    the first re-emitted CREATE TABLE and failed with "table already exists".
+    """
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "partition_1.csv": seed_partition_1_csv,
+            "partition_1_replaced_plus_2.csv": seed_partition_1_replaced_plus_2_csv,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_external.sql": external_catalog_incremental_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        # A default so the model parses before the first --vars override.
+        return {"vars": {"seed_name": "partition_1"}}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_external_catalog(self, project):
+        project.run_sql("""
+            CREATE DATABASE IF NOT EXISTS iceberg_catalog.dbt_test_db
+            PROPERTIES ("location" = "s3://warehouse/dbt_test_db")
+        """)
+        yield
+
+        project.run_sql("DROP TABLE IF EXISTS iceberg_catalog.dbt_test_db.incremental_external")
+        project.run_sql("DROP DATABASE IF EXISTS iceberg_catalog.dbt_test_db FORCE")
+
+    @staticmethod
+    def _ids_by_partition(project):
+        rows = project.run_sql(
+            "select partition_key, id"
+            " from iceberg_catalog.dbt_test_db.incremental_external"
+            " order by partition_key, id",
+            fetch="all",
+        )
+        ids_by_partition = {}
+        for partition_key, id_ in rows:
+            ids_by_partition.setdefault(partition_key, []).append(id_)
+        return ids_by_partition
+
+    def test_incremental_dynamic_overwrite(self, project):
+        assert len(run_dbt(["seed"])) == 2
+
+        # First run creates the Iceberg table.
+        assert len(run_dbt(["run", "--vars", "seed_name: partition_1"])) == 1
+        assert self._ids_by_partition(project) == {1: [1, 2, 3, 4, 5]}
+
+        # Second run must reach the insert instead of re-creating the table.
+        assert len(run_dbt(["run", "--vars", "seed_name: partition_1_replaced_plus_2"])) == 1
+
+        # Partition 1 is replaced in place rather than appended to, and the
+        # partition the query newly produced is created.
+        assert self._ids_by_partition(project) == {
+            1: [6, 7, 8, 9, 10],
+            2: [11, 12, 13, 14, 15],
+        }
+
+        # Dynamic overwrite leaves a partition the query no longer produces alone.
+        assert len(run_dbt(["run", "--vars", "seed_name: partition_1"])) == 1
+        assert self._ids_by_partition(project) == {
+            1: [1, 2, 3, 4, 5],
+            2: [11, 12, 13, 14, 15],
+        }
+
+        # External catalogs have no ALTER TABLE ... SWAP WITH, so --full-refresh
+        # drops and recreates: only what the query produces survives.
+        assert len(run_dbt(["run", "--full-refresh", "--vars", "seed_name: partition_1"])) == 1
+        assert self._ids_by_partition(project) == {1: [1, 2, 3, 4, 5]}


### PR DESCRIPTION
## Description
Fix incremental and table models targeting external catalogs, which failed on every run after the first with `Table '<name>' already exists`. Relations in an external catalog were invisible to the relation cache — `starrocks__list_relations_without_caching` and `starrocks__get_columns_in_relation` queried an unqualified `information_schema` (which resolves in the session's current catalog) and reported `null` as the relation's database, and `get_relation` dropped the database component outright — so `load_relation` always returned none and the materializations re-emitted `CREATE TABLE`. Both macros now qualify `information_schema` with the catalog and carry it back as the relation's database, and the adapter preserves that component when it names an external catalog; the incremental materialization looks its target up by catalog rather than through `this` (which always addresses `default_catalog`), and `--full-refresh` drops and recreates instead of using `ALTER TABLE ... SWAP WITH`, which external catalogs do not support. 