### PR TITLE
Pull MinIO images from quay.io to unblock CI

### DIFF
--- a/.github/docker-compose.iceberg.yml
+++ b/.github/docker-compose.iceberg.yml
@@ -39,7 +39,7 @@ services:
       - CATALOG_S3_ENDPOINT=http://minio:9000
 
   minio:
-    image: minio/minio:RELEASE.2024-10-29T16-01-48Z
+    image: quay.io/minio/minio:RELEASE.2024-10-29T16-01-48Z
     container_name: minio
     environment:
       - MINIO_ROOT_USER=admin
@@ -57,7 +57,7 @@ services:
   mc:
     depends_on:
       - minio
-    image: minio/mc:RELEASE.2024-10-29T15-34-59Z
+    image: quay.io/minio/mc:RELEASE.2024-10-29T15-34-59Z
     container_name: mc
     networks:
       iceberg_net:


### PR DESCRIPTION
MinIO's images are no longer available on Docker Hub, so every `integration-test` job fails at the **Start Iceberg stack** step, ~20s in, before dependencies are installed or a single test runs:

```
mc Error pull access denied for minio/mc, repository does not exist
    or may require 'docker login': denied
```

This is environmental rather than specific to any change — it affects every run of the workflow, and `main` last ran green on 2026-08-10.

| image | Docker Hub | quay.io |
|---|---|---|
| `minio/minio:RELEASE.2024-10-29T16-01-48Z` | denied | available |
| `minio/mc:RELEASE.2024-10-29T15-34-59Z` | denied | available |
| `minio/minio:latest`, `minio/mc:latest` | denied | available |

This points the `minio` and `mc` services at quay.io, keeping the exact same pinned release tags so nothing else about the stack changes.

Verified by deleting the locally cached Docker Hub images first so the pull was real, then bringing the full stack up on StarRocks 3.5.14, confirming `mc` bootstrapped the `warehouse` bucket, and running both suites: **28 unit passed, 32 functional passed / 3 skipped**.

Split out of #120 so it can merge ahead of it and unblock the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)